### PR TITLE
Add incremental adaptive infrared-based rotation. #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In [`example/EmbeddedChessPieces/examples`](./example/EmbeddedChessPieces/exampl
 
 | Context    | Description                                                                         |
 |------------|-------------------------------------------------------------------------------------|
-| Module     | C377.2 Prinzipien von Programmiersprachen                                           |
+| Module     | C999 Software Development for Embedded Systems                                      |
 | Lecturer   | Prof. Dr. rer. nat. Jens Wagner, M. Eng. Marian Ulbricht                            |
 | Institute  | Leipzig University of Applied Sciences                                              |
 | Semester   | Winter Semester 2024/25                                                             |

--- a/example/EmbeddedChessPieces/examples/ir_sensors/README.md
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/README.md
@@ -1,0 +1,6 @@
+# IR Sensors
+
+This directory contains two sketches regarding infrared sensors.
+
+- `ir_emitter.ino` emits an infrared signal from the dezibot. This sketch is needed for the rotation functions in *Embedded Chess Pieces* as a guide for the dezibot (see [`ECPMovement`](../../src/ECPMovement/ECPMovement.h)).
+- `ir_sensors.ino` is a test sketch to validate the angle measurements and calculations of [`ECPSignalDetection`](../../src/ECPSignalDetection/ECPSignalDetection.h). It calculates the angle of the signal relative to the dezibot and infers the angle the dezibot is facing.

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_emitter/ir_emitter.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_emitter/ir_emitter.ino
@@ -1,0 +1,32 @@
+/**
+ * @file ir_emitter.ino
+ * @author Ines Rohrbach, Nico Schramm
+ * @brief Sketch to emit IR light
+ * @version 0.1
+ * @date 2025-01-21
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ */
+
+#include <Dezibot.h>
+
+Dezibot dezibot = Dezibot();
+
+void setup() {
+    dezibot.begin();
+    delay(10);
+
+    dezibot.infraredLight.front.turnOn();
+    dezibot.display.println("IR turned on");
+}
+
+void loop() {
+    // dezibot.infraredLight.front.turnOn();
+    // dezibot.display.println("IR turned on");
+    // delay(10000);
+
+    // dezibot.infraredLight.front.turnOff();
+    // dezibot.display.println("IR turned off");
+    // delay(10000);
+}

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_emitter/ir_emitter.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_emitter/ir_emitter.ino
@@ -21,12 +21,4 @@ void setup() {
     dezibot.display.println("IR turned on");
 }
 
-void loop() {
-    // dezibot.infraredLight.front.turnOn();
-    // dezibot.display.println("IR turned on");
-    // delay(10000);
-
-    // dezibot.infraredLight.front.turnOff();
-    // dezibot.display.println("IR turned off");
-    // delay(10000);
-}
+void loop() {}

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
@@ -17,14 +17,18 @@ ECPSignalDetection ecpSignalDetection = ECPSignalDetection(dezibot);
 
 void setup() {
     dezibot.begin();
+    dezibot.display.flipOrientation();
     delay(100);
 }
 
 void loop() {
     dezibot.display.clear();
 
-    int angle = ecpSignalDetection.measureSignalAngle();
-    dezibot.display.println(String(angle));
+    int signalAngle = ecpSignalDetection.measureDezibotAngle();
+    dezibot.display.println("S: " + String(signalAngle));
+
+    int dezibotAngle = ecpSignalDetection.measureDezibotAngle();
+    dezibot.display.println("D: " + String(dezibotAngle));
 
     delay(500);
 }

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
@@ -27,12 +27,8 @@ void setup() {
 void loop() {
     dezibot.display.clear();
 
-    float angle = ecpSignalDetection.measureSignalAngle();
-    if (angle == -1.0f) {
-        dezibot.display.println("no signal");
-    } else {
-        dezibot.display.println(String(angle));
-    }
+    int angle = ecpSignalDetection.measureSignalAngle();
+    dezibot.display.println(String(angle));
 
     delay(500);
 }

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
@@ -35,18 +35,19 @@ void loop() {
             MEAS_COUNT,
             TIME_BETWEEN_MEAS
         );
-        printValue(irValue, sensor);
+        const float normalizedValue = dezibot.lightDetection.normalizeValue(irValue);
+        printValue(normalizedValue, sensor);
     }
 
     delay(500);
 }
 
-void printValue(uint16_t irValue, photoTransistors sensor) {
+void printValue(float irValue, photoTransistors sensor) {
     const String s = ptString(sensor);
     dezibot.display.print(s + " ");
     Serial.print(s);
 
-    dezibot.display.println(irValue);
+    dezibot.display.println(String(irValue));
     Serial.println(irValue);
 }
 

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
@@ -1,0 +1,66 @@
+/**
+ * @file ir_sensors.ino
+ * @author Ines Rohrbach, Nico Schramm
+ * @brief Test sketch for receiving IR light
+ * @version 0.1
+ * @date 2025-01-21
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ */
+
+#include <Dezibot.h>
+
+#define BAUD_RATE 9600
+
+#define MEAS_COUNT 3
+#define TIME_BETWEEN_MEAS 1 // ms
+
+Dezibot dezibot = Dezibot();
+
+void setup() {
+    Serial.begin(BAUD_RATE);
+    dezibot.begin();
+    dezibot.display.flipOrientation();
+    delay(10);
+}
+
+void loop() {
+    const photoTransistors sensors[] = { IR_FRONT, IR_RIGHT, IR_BACK, IR_LEFT };
+
+    dezibot.display.clear();
+    for (const photoTransistors sensor : sensors) {
+        const int irValue = dezibot.lightDetection.getAverageValue(
+            sensor,
+            MEAS_COUNT,
+            TIME_BETWEEN_MEAS
+        );
+        printValue(irValue, sensor);
+    }
+
+    delay(500);
+}
+
+void printValue(uint16_t irValue, photoTransistors sensor) {
+    const String s = ptString(sensor);
+    dezibot.display.print(s + " ");
+    Serial.print(s);
+
+    dezibot.display.println(irValue);
+    Serial.println(irValue);
+}
+
+String ptString(photoTransistors sensor) {
+    switch (sensor) {
+        case IR_LEFT:
+            return "W";
+        case IR_RIGHT:
+            return "E";
+        case IR_FRONT:
+            return "N";
+        case IR_BACK:
+            return "S";
+        default:
+            return " ";
+    }
+}

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
@@ -24,7 +24,7 @@ void setup() {
 void loop() {
     dezibot.display.clear();
 
-    int signalAngle = ecpSignalDetection.measureDezibotAngle();
+    int signalAngle = ecpSignalDetection.measureSignalAngle();
     dezibot.display.println("S: " + String(signalAngle));
 
     int dezibotAngle = ecpSignalDetection.measureDezibotAngle();

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
@@ -16,11 +16,7 @@ Dezibot dezibot = Dezibot();
 ECPSignalDetection ecpSignalDetection = ECPSignalDetection(dezibot);
 
 void setup() {
-    Serial.begin(9600);
-
     dezibot.begin();
-    dezibot.display.flipOrientation();
-
     delay(100);
 }
 

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
@@ -1,7 +1,7 @@
 /**
  * @file ir_sensors.ino
  * @author Ines Rohrbach, Nico Schramm
- * @brief Test sketch for receiving IR light
+ * @brief Test sketch for measuring the angle of an IR signal
  * @version 0.1
  * @date 2025-01-21
  * 

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_sensors/ir_sensors.ino
@@ -10,58 +10,29 @@
  */
 
 #include <Dezibot.h>
-
-#define BAUD_RATE 9600
-
-#define MEAS_COUNT 3
-#define TIME_BETWEEN_MEAS 1 // ms
+#include <EmbeddedChessPieces.h>
 
 Dezibot dezibot = Dezibot();
+ECPSignalDetection ecpSignalDetection = ECPSignalDetection(dezibot);
 
 void setup() {
-    Serial.begin(BAUD_RATE);
+    Serial.begin(9600);
+
     dezibot.begin();
     dezibot.display.flipOrientation();
-    delay(10);
+
+    delay(100);
 }
 
 void loop() {
-    const photoTransistors sensors[] = { IR_FRONT, IR_RIGHT, IR_BACK, IR_LEFT };
-
     dezibot.display.clear();
-    for (const photoTransistors sensor : sensors) {
-        const int irValue = dezibot.lightDetection.getAverageValue(
-            sensor,
-            MEAS_COUNT,
-            TIME_BETWEEN_MEAS
-        );
-        const float normalizedValue = dezibot.lightDetection.normalizeValue(irValue);
-        printValue(normalizedValue, sensor);
+
+    float angle = ecpSignalDetection.measureSignalAngle();
+    if (angle == -1.0f) {
+        dezibot.display.println("no signal");
+    } else {
+        dezibot.display.println(String(angle));
     }
 
     delay(500);
-}
-
-void printValue(float irValue, photoTransistors sensor) {
-    const String s = ptString(sensor);
-    dezibot.display.print(s + " ");
-    Serial.print(s);
-
-    dezibot.display.println(String(irValue));
-    Serial.println(irValue);
-}
-
-String ptString(photoTransistors sensor) {
-    switch (sensor) {
-        case IR_LEFT:
-            return "W";
-        case IR_RIGHT:
-            return "E";
-        case IR_FRONT:
-            return "N";
-        case IR_BACK:
-            return "S";
-        default:
-            return " ";
-    }
 }

--- a/example/EmbeddedChessPieces/examples/movement/rotate_90/rotate_90.ino
+++ b/example/EmbeddedChessPieces/examples/movement/rotate_90/rotate_90.ino
@@ -11,7 +11,6 @@
 
 #include <Dezibot.h>
 #include <EmbeddedChessPieces.h>
-#include <Wire.h>
 
 // change for a calibration fitting the specific dezibot
 #define MOVEMENT_CALIBRATION 3900
@@ -20,24 +19,22 @@ Dezibot dezibot = Dezibot();
 ECPMovement ecpMovement(dezibot, MOVEMENT_CALIBRATION);
 
 void setup() {
-  Serial.begin(9600);
-  Serial.println("Started");
   dezibot.begin();
-  Serial.println("Initialised");
+  dezibot.display.flipOrientation();
   delay(500);
 }
 
 void loop() {
   dezibot.display.println("Turning left...");
-  ecpMovement.turnLeft({A, 1}, NORTH);
+  ecpMovement.turnLeft({A, 1}, WEST);
   dezibot.display.println("Done");
-  delay(2000);
+  delay(10000);
 
   dezibot.display.println("Turning right...");
   ecpMovement.turnRight({A, 1}, NORTH);
   dezibot.display.println("Done");
   
-  dezibot.display.println("\nSleeping for 10s...");
+  dezibot.display.println("\Sleep 10s");
   delay(10000);
   dezibot.display.clear();
 }

--- a/example/EmbeddedChessPieces/examples/movement/rotate_90/rotate_90.ino
+++ b/example/EmbeddedChessPieces/examples/movement/rotate_90/rotate_90.ino
@@ -15,16 +15,9 @@
 
 // change for a calibration fitting the specific dezibot
 #define MOVEMENT_CALIBRATION 3900
-#define ROTATION_TIME_LEFT 2750
-#define ROTATION_TIME_RIGHT 2550
 
 Dezibot dezibot = Dezibot();
-ECPMovement ecpMovement(
-  dezibot, 
-  MOVEMENT_CALIBRATION, 
-  ROTATION_TIME_LEFT, 
-  ROTATION_TIME_RIGHT
-);
+ECPMovement ecpMovement(dezibot, MOVEMENT_CALIBRATION);
 
 void setup() {
   Serial.begin(9600);

--- a/example/EmbeddedChessPieces/examples/movement/rotate_90/rotate_90.ino
+++ b/example/EmbeddedChessPieces/examples/movement/rotate_90/rotate_90.ino
@@ -21,7 +21,7 @@ ECPMovement ecpMovement(dezibot, MOVEMENT_CALIBRATION);
 void setup() {
   dezibot.begin();
   dezibot.display.flipOrientation();
-  delay(500);
+  delay(5000);
 }
 
 void loop() {

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -14,20 +14,6 @@ void ECPMovement::move(uint numberOfFields) {
     }
 };
 
-void ECPMovement::displayRotionCorrectionRequest(
-    ECPChessField currentField, 
-    ECPDirection intendedDirection
-) {
-    String request = "Faulty rotation\nPlease correct\nmy position in\n" 
-        + String(ROTATION_CORRECTION_TIME/1000) + " seconds to\n\n> " 
-        + currentField.toString() + " " + directionToString(intendedDirection) 
-        + "\n\n Thank you!";
-    dezibot.display.clear();
-    dezibot.display.print(request);
-    delay(ROTATION_CORRECTION_TIME);
-    dezibot.display.clear();
-};
-
 void ECPMovement::turnLeft(
     ECPChessField currentField, 
     ECPDirection intendedDirection
@@ -88,6 +74,20 @@ void ECPMovement::moveToNextField() {
         moveForward(FORWARD_TIME, MOVEMENT_BREAK);
         isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
     }
+};
+
+void ECPMovement::displayRotionCorrectionRequest(
+    ECPChessField currentField, 
+    ECPDirection intendedDirection
+) {
+    String request = "Faulty rotation\nPlease correct\nmy position in\n" 
+        + String(ROTATION_CORRECTION_TIME/1000) + " seconds to\n\n> " 
+        + currentField.toString() + " " + directionToString(intendedDirection) 
+        + "\n\n Thank you!";
+    dezibot.display.clear();
+    dezibot.display.print(request);
+    delay(ROTATION_CORRECTION_TIME);
+    dezibot.display.clear();
 };
 
 void ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -26,11 +26,11 @@ void ECPMovement::turnLeft(
     // add 360 before applying modulo to prevent negative values
     const int goalAngle = (initialAngle - 90 + 360) % 360;
     
-    rotateToAngle(goalAngle, initialAngle);
+    const bool wasRotationSuccessful = rotateToAngle(goalAngle, initialAngle);
 
     delay(MEASURING_DELAY); // for better measuring results
     const bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
-    if (isCurrentlyOnWhite != hasStartedOnWhite) {
+    if (isCurrentlyOnWhite != hasStartedOnWhite || !wasRotationSuccessful) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
     }
 };
@@ -46,11 +46,11 @@ void ECPMovement::turnRight(
     // in the dezibot facing 270°
     const int goalAngle = (initialAngle + 90) % 360;
 
-    rotateToAngle(goalAngle, initialAngle);
+    const bool wasRotationSuccessful = rotateToAngle(goalAngle, initialAngle);
 
     delay(MEASURING_DELAY); // for better measuring results
     const bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
-    if (isCurrentlyOnWhite != hasStartedOnWhite) {
+    if (isCurrentlyOnWhite != hasStartedOnWhite || !wasRotationSuccessful) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
     }
 };
@@ -90,7 +90,7 @@ void ECPMovement::displayRotionCorrectionRequest(
     dezibot.display.clear();
 };
 
-void ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {
+bool ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {
     int currentAngle = initialAngle;
     int difference = goalAngle - currentAngle;
     size_t currentIteration = 0;
@@ -122,14 +122,12 @@ void ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {
     }
 
     if (currentIteration == MAX_ROTATION_ITERATIONS) {
-        dezibot.display.clear();
-        dezibot.display.println("exceeded max iterations");
-        dezibot.display.println("please turn bot to face "
-            + String(currentAngle));
-        dezibot.display.println("waiting for 10 seconds...");
-        delay(10 * 1000);
-        dezibot.display.println("continuing...");
+        // rotation failed
+        return false;
     }
+
+    // rotation successful
+    return true;
 };
 
 void ECPMovement::rotateLeft(uint movementTime) {

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -28,7 +28,7 @@ void ECPMovement::turnLeft(
     
     rotateToAngle(goalAngle, initialAngle);
 
-    delay(5); // for better measuring results
+    delay(MEASURING_DELAY); // for better measuring results
     const bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
     if (isCurrentlyOnWhite != hasStartedOnWhite) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
@@ -48,7 +48,7 @@ void ECPMovement::turnRight(
 
     rotateToAngle(goalAngle, initialAngle);
 
-    delay(5); // for better measuring results
+    delay(MEASURING_DELAY); // for better measuring results
     const bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
     if (isCurrentlyOnWhite != hasStartedOnWhite) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
@@ -111,13 +111,12 @@ void ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {
             rotateRight(rotationTime);
         }
 
-        // delay for better measuring results
-        delay(5);
-
+        delay(MEASURING_DELAY); // for better measuring results
         currentAngle = ecpSignalDetection.measureDezibotAngle();
-        difference = goalAngle - currentAngle;
-        currentIteration++;
 
+        difference = goalAngle - currentAngle;
+        
+        currentIteration++;
         shouldContinueRotation = std::abs(difference) > ROTATION_TOLERANCE
             && currentIteration < MAX_ROTATION_ITERATIONS;
     }
@@ -145,8 +144,7 @@ void ECPMovement::rotateRight(uint movementTime) {
     dezibot.motion.left.setSpeed(0);
 };
 
-uint ECPMovement::calculateRotationTime(int angleDifference) {
-    float normalizedDifference = ((angleDifference + 180) % 360) - 180;
-    float rotationTime = ROTATION_TIME_FACTOR * std::abs(normalizedDifference);
+uint ECPMovement::calculateRotationTime(int normalizedAngleDifference) {
+    float rotationTime = ROTATION_TIME_FACTOR * std::abs(normalizedAngleDifference);
     return std::round(rotationTime);
 };

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -34,7 +34,12 @@ void ECPMovement::turnLeft(
 ) {
     const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
     int initialAngle = ecpSignalDetection.measureSignalAngle();
-    int goalAngle = (initialAngle - 90) % 360;
+    
+    // if dezibot faces initially at 180°, subtract 90° to turn left, resulting
+    // in the dezibot facing 90°
+    // add 360 in parentheses to prevent negative values
+    int goalAngle = (initialAngle - 90 + 360) % 360;
+    
     rotateToAngle(goalAngle, initialAngle);
 
     delay(5); // for better measuring results
@@ -50,7 +55,11 @@ void ECPMovement::turnRight(
 ) {
     const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
     int initialAngle = ecpSignalDetection.measureSignalAngle();
+
+    // if dezibot faces initially at 180°, add 90° to turn left, resulting in
+    // the dezibot facing 270°
     int goalAngle = (initialAngle + 90) % 360;
+
     rotateToAngle(goalAngle, initialAngle);
 
     delay(5); // for better measuring results
@@ -90,7 +99,7 @@ void ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {
         && currentIteration < MAX_ROTATION_ITERATIONS;
 
     while (shouldContinueRotation) {
-        int normalizedDifference = ((difference + 180) % 360) - 180;
+        int normalizedDifference = ((difference + 180 + 360) % 360) - 180;
         uint rotationTime = calculateRotationTime(normalizedDifference);
 
         if (normalizedDifference == 0 || normalizedDifference == -180) {
@@ -105,7 +114,7 @@ void ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {
         // delay for better measuring results
         delay(5);
 
-        currentAngle = ecpSignalDetection.measureSignalAngle();
+        currentAngle = ecpSignalDetection.measureDezibotAngle();
         difference = goalAngle - currentAngle;
         currentIteration++;
 
@@ -125,15 +134,15 @@ void ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {
 };
 
 void ECPMovement::rotateLeft(uint movementTime) {
-    dezibot.motion.left.setSpeed(ROTATION_SPEED);
-    delay(movementTime);
-    dezibot.motion.left.setSpeed(0);
-};
-
-void ECPMovement::rotateRight(uint movementTime) {
     dezibot.motion.right.setSpeed(ROTATION_SPEED);
     delay(movementTime);
     dezibot.motion.right.setSpeed(0);
+};
+
+void ECPMovement::rotateRight(uint movementTime) {
+    dezibot.motion.left.setSpeed(ROTATION_SPEED);
+    delay(movementTime);
+    dezibot.motion.left.setSpeed(0);
 };
 
 uint ECPMovement::calculateRotationTime(int angleDifference) {

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -19,17 +19,17 @@ void ECPMovement::turnLeft(
     ECPDirection intendedDirection
 ) {
     const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
-    int initialAngle = ecpSignalDetection.measureSignalAngle();
+    const int initialAngle = ecpSignalDetection.measureSignalAngle();
     
     // if dezibot initially faces 270°, subtract 90° to turn left, resulting
     // in the dezibot facing 180°
     // add 360 before applying modulo to prevent negative values
-    int goalAngle = (initialAngle - 90 + 360) % 360;
+    const int goalAngle = (initialAngle - 90 + 360) % 360;
     
     rotateToAngle(goalAngle, initialAngle);
 
     delay(5); // for better measuring results
-    bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
+    const bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
     if (isCurrentlyOnWhite != hasStartedOnWhite) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
     }
@@ -40,16 +40,16 @@ void ECPMovement::turnRight(
     ECPDirection intendedDirection
 ) {
     const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
-    int initialAngle = ecpSignalDetection.measureSignalAngle();
+    const int initialAngle = ecpSignalDetection.measureSignalAngle();
 
     // if dezibot initially faces 180°, add 90° to turn left, resulting
     // in the dezibot facing 270°
-    int goalAngle = (initialAngle + 90) % 360;
+    const int goalAngle = (initialAngle + 90) % 360;
 
     rotateToAngle(goalAngle, initialAngle);
 
     delay(5); // for better measuring results
-    bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
+    const bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
     if (isCurrentlyOnWhite != hasStartedOnWhite) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
     }

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -1,15 +1,12 @@
 #include "ECPMovement.h"
 
 ECPMovement::ECPMovement(
-  Dezibot &dezibot,
-  uint movementCalibration,
-  uint rotationTimeLeft,
-  uint rotationTimeRight
+    Dezibot &dezibot,
+    uint movementCalibration
 ) : dezibot(dezibot),
     ecpColorDetection(ECPColorDetection(dezibot)),
-    movementCalibration(movementCalibration),
-    rotationTimeLeft(rotationTimeLeft),
-    rotationTimeRight(rotationTimeRight) {};
+    ecpSignalDetection(ECPSignalDetection(dezibot)),
+    movementCalibration(movementCalibration) {};
 
 void ECPMovement::moveForward(int timeMovement, int timeBreak) {
     dezibot.motion.move(0, movementCalibration);
@@ -34,40 +31,6 @@ void ECPMovement::move(uint numberOfFields) {
     }
 };
 
-void ECPMovement::turnLeft(
-    ECPChessField currentField, 
-    ECPDirection intendedDirection
-) {
-    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
-
-    dezibot.motion.right.setSpeed(ROTATION_SPEED);
-    delay(rotationTimeLeft);
-    dezibot.motion.right.setSpeed(0);
-    delay(MOVEMENT_BREAK);
-    
-    bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
-    if (isCurrentlyOnWhite != hasStartedOnWhite) {
-        displayRotionCorrectionRequest(currentField, intendedDirection);
-    }
-};
-
-void ECPMovement::turnRight(
-    ECPChessField currentField, 
-    ECPDirection intendedDirection
-) {
-    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
-
-    dezibot.motion.left.setSpeed(ROTATION_SPEED);
-    delay(rotationTimeRight);
-    dezibot.motion.left.setSpeed(0);
-    delay(MOVEMENT_BREAK);
-
-    bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
-    if (isCurrentlyOnWhite != hasStartedOnWhite) {
-        displayRotionCorrectionRequest(currentField, intendedDirection);
-    }
-};
-
 void ECPMovement::displayRotionCorrectionRequest(
     ECPChessField currentField, 
     ECPDirection intendedDirection
@@ -80,4 +43,97 @@ void ECPMovement::displayRotionCorrectionRequest(
     dezibot.display.print(request);
     delay(ROTATION_CORRECTION_TIME);
     dezibot.display.clear();
+};
+
+void ECPMovement::turnLeft(
+    ECPChessField currentField, 
+    ECPDirection intendedDirection
+) {
+    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
+    int initialAngle = ecpSignalDetection.measureSignalAngle();
+    int goalAngle = (initialAngle - 90) % 360;
+    rotateToAngle(goalAngle, initialAngle);
+
+    delay(5); // for better measuring results
+    bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
+    if (isCurrentlyOnWhite != hasStartedOnWhite) {
+        displayRotionCorrectionRequest(currentField, intendedDirection);
+    }
+};
+
+void ECPMovement::turnRight(
+    ECPChessField currentField, 
+    ECPDirection intendedDirection
+) {
+    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
+    int initialAngle = ecpSignalDetection.measureSignalAngle();
+    int goalAngle = (initialAngle + 90) % 360;
+    rotateToAngle(goalAngle, initialAngle);
+
+    delay(5); // for better measuring results
+    bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
+    if (isCurrentlyOnWhite != hasStartedOnWhite) {
+        displayRotionCorrectionRequest(currentField, intendedDirection);
+    }
+};
+
+void ECPMovement::rotateToAngle(int goalAngle, int initialAngle) {
+    int currentAngle = initialAngle;
+    int difference = goalAngle - currentAngle;
+    size_t currentIteration = 0;
+
+    bool shouldContinueRotation = std::abs(difference) > ROTATION_TOLERANCE
+        && currentIteration < MAX_ROTATION_ITERATIONS;
+
+    while (shouldContinueRotation) {
+        int normalizedDifference = ((difference + 180) % 360) - 180;
+        uint rotationTime = calculateRotationTime(normalizedDifference);
+
+        if (normalizedDifference == 0 || normalizedDifference == -180) {
+            // exactly opposed to goal angle, rotation direction does not matter
+            rotateLeft(rotationTime);
+        } else if (normalizedDifference < 0) {
+            rotateLeft(rotationTime);
+        } else {
+            rotateRight(rotationTime);
+        }
+
+        // delay for better measuring results
+        delay(5);
+
+        currentAngle = ecpSignalDetection.measureSignalAngle();
+        difference = goalAngle - currentAngle;
+        currentIteration++;
+
+        shouldContinueRotation = std::abs(difference) > ROTATION_TOLERANCE
+            && currentIteration < MAX_ROTATION_ITERATIONS;
+    }
+
+    if (currentIteration == MAX_ROTATION_ITERATIONS) {
+        dezibot.display.clear();
+        dezibot.display.println("exceeded max iterations");
+        dezibot.display.println("please turn bot to face "
+            + String(currentAngle));
+        dezibot.display.println("waiting for 10 seconds...");
+        delay(10 * 1000);
+        dezibot.display.println("continuing...");
+    }
+};
+
+void ECPMovement::rotateLeft(uint movementTime) {
+    dezibot.motion.left.setSpeed(ROTATION_SPEED);
+    delay(movementTime);
+    dezibot.motion.left.setSpeed(0);
+};
+
+void ECPMovement::rotateRight(uint movementTime) {
+    dezibot.motion.right.setSpeed(ROTATION_SPEED);
+    delay(movementTime);
+    dezibot.motion.right.setSpeed(0);
+};
+
+uint ECPMovement::calculateRotationTime(int angleDifference) {
+    float normalizedDifference = ((angleDifference + 180) % 360) - 180;
+    float rotationTime = ROTATION_TIME_FACTOR * std::abs(normalizedDifference);
+    return std::round(rotationTime);
 };

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -19,7 +19,7 @@ void ECPMovement::turnLeft(
     ECPDirection intendedDirection
 ) {
     const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
-    const int initialAngle = ecpSignalDetection.measureSignalAngle();
+    const int initialAngle = ecpSignalDetection.measureDezibotAngle();
     
     // if dezibot initially faces 270°, subtract 90° to turn left, resulting
     // in the dezibot facing 180°
@@ -40,7 +40,7 @@ void ECPMovement::turnRight(
     ECPDirection intendedDirection
 ) {
     const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
-    const int initialAngle = ecpSignalDetection.measureSignalAngle();
+    const int initialAngle = ecpSignalDetection.measureDezibotAngle();
 
     // if dezibot initially faces 180°, add 90° to turn left, resulting
     // in the dezibot facing 270°

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -35,9 +35,9 @@ void ECPMovement::turnLeft(
     const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
     int initialAngle = ecpSignalDetection.measureSignalAngle();
     
-    // if dezibot faces initially at 180°, subtract 90° to turn left, resulting
-    // in the dezibot facing 90°
-    // add 360 in parentheses to prevent negative values
+    // if dezibot initially faces 270°, subtract 90° to turn left, resulting
+    // in the dezibot facing 180°
+    // add 360 before applying modulo to prevent negative values
     int goalAngle = (initialAngle - 90 + 360) % 360;
     
     rotateToAngle(goalAngle, initialAngle);
@@ -56,8 +56,8 @@ void ECPMovement::turnRight(
     const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
     int initialAngle = ecpSignalDetection.measureSignalAngle();
 
-    // if dezibot faces initially at 180°, add 90° to turn left, resulting in
-    // the dezibot facing 270°
+    // if dezibot initially faces 180°, add 90° to turn left, resulting
+    // in the dezibot facing 270°
     int goalAngle = (initialAngle + 90) % 360;
 
     rotateToAngle(goalAngle, initialAngle);

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -8,23 +8,6 @@ ECPMovement::ECPMovement(
     ecpSignalDetection(ECPSignalDetection(dezibot)),
     movementCalibration(movementCalibration) {};
 
-void ECPMovement::moveForward(int timeMovement, int timeBreak) {
-    dezibot.motion.move(0, movementCalibration);
-    delay(timeMovement);
-    dezibot.motion.stop();
-    delay(timeBreak);
-};
-
-void ECPMovement::moveToNextField() {
-    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
-    bool isCurrentlyOnWhite = hasStartedOnWhite;
-
-    while (isCurrentlyOnWhite == hasStartedOnWhite) {
-        moveForward(FORWARD_TIME, MOVEMENT_BREAK);
-        isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
-    }
-};
-
 void ECPMovement::move(uint numberOfFields) {
     for (size_t i = 0; i < numberOfFields; i++) {
         moveToNextField();
@@ -74,6 +57,27 @@ void ECPMovement::turnRight(
     bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
     if (isCurrentlyOnWhite != hasStartedOnWhite) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
+    }
+};
+
+// -----------------------------------------------------------------------------
+// PRIVATE FUNCTIONS
+// -----------------------------------------------------------------------------
+
+void ECPMovement::moveForward(int timeMovement, int timeBreak) {
+    dezibot.motion.move(0, movementCalibration);
+    delay(timeMovement);
+    dezibot.motion.stop();
+    delay(timeBreak);
+};
+
+void ECPMovement::moveToNextField() {
+    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
+    bool isCurrentlyOnWhite = hasStartedOnWhite;
+
+    while (isCurrentlyOnWhite == hasStartedOnWhite) {
+        moveForward(FORWARD_TIME, MOVEMENT_BREAK);
+        isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
     }
 };
 

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -122,7 +122,7 @@ private:
      * 
      * @see calculateRotationTime() for details on how the rotation time is computed.
      * @see rotateLeft() and rotateRight() for the actual rotation implementations.
-     * @see ecpSignalDetection.measureSignalAngle() for how the current angle is measured.
+     * @see ecpSignalDetection.measureDezibotAngle() for how the current angle is measured.
      */
     void rotateToAngle(int goalAngle, int initialAngle);
 
@@ -131,7 +131,8 @@ private:
      * 
      * Use left motor of the dezibot (`dezibot.motion.left`).
      * 
-     * @param movementTime Duration for which the bot should rotate left, in milliseconds.
+     * @param movementTime Duration for which the bot should rotate left, in
+     *                     milliseconds.
      * 
      * @details This function is typically called as part of a larger rotation
      *          mechanism, where the duration of the left rotation is calculated
@@ -144,7 +145,8 @@ private:
      * 
      * Use left motor of the dezibot (`dezibot.motion.right`).
      * 
-     * @param movementTime Duration for which the bot should rotate right, in milliseconds.
+     * @param movementTime Duration for which the bot should rotate right, in
+     *                     milliseconds.
      * 
      * @details This function is typically called as part of a larger rotation
      *          mechanism, where the duration of the left rotation is calculated

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -23,6 +23,7 @@
 #define ROTATION_SPEED 8192
 #define ROTATION_CORRECTION_TIME 10000
 #define DEFAULT_MOVEMENT_CALIBRATION 3900
+#define MEASURING_DELAY 5
 
 class ECPMovement {
 public:
@@ -161,16 +162,14 @@ private:
      * Compute the rotation time needed to adjust the dezibot's angle based on
      * the difference between the current angle and the target angle.
      *
-     * @param angleDifference Difference in angle between the current and target
-     *                        positions, in degrees.
+     * @param normalizedAngleDifference Difference in angle between the current
+     *            and target positions, in degrees, normalized to [-180, 180].
      *
      * @return uint Calculated rotation time (in milliseconds) rounded to the
      *              nearest integer.
      * 
-     * @details The calculation normalizes the angle difference to ensure it
-     *          falls within the range of 0 to 180 degrees, and then derives the
-     *          rotation time using a linear relationship.
-     *          It is assumed that a 180° rotation takes about 5000 milliseconds
+     * @details The rotation time is derived using a linear relationship. It is
+     *          assumed that a 180° rotation takes about 5000 milliseconds
      *          Therefore, the angle is multiplied by 28 which approximates this
      *          assumption (180° * 28 = 5040 ms).
      * 
@@ -178,7 +177,7 @@ private:
      *      rotating the dezibot to a specific angle.
      * @see ROTATION_TIME_FACTOR for factor used to define linear relationship.
      */
-    uint calculateRotationTime(int angleDifference);
+    uint calculateRotationTime(int normalizedAngleDifference);
 
     /**
      * @brief Tolerance for a rotation to be accepted in degrees.

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -110,10 +110,10 @@ private:
      * 
      * This function uses an incremental approach. Based on the difference of
      * the two angles, incrementally rotate the bot toward the goal. Use
-     * the tolerance specified in `ROTATION_TOLERANCE`.
+     * the tolerance specified in \p ROTATION_TOLERANCE.
      * 
      * If the rotation could not be completed successfully after a certain
-     * amount of iterations (cf. `MAX_ROTATION_ITERATIONS`), print a statement
+     * amount of iterations (cf. \p MAX_ROTATION_ITERATIONS), print a statement
      * on the display to request manual correction within 10 seconds before
      * continuing.
      * 
@@ -121,15 +121,15 @@ private:
      * @param initialAngle Measured initial angle of the dezibot, in degrees.
      * 
      * @see calculateRotationTime() for details on how the rotation time is computed.
-     * @see rotateLeft() and rotateRight() for the actual rotation implementations.
-     * @see ecpSignalDetection.measureDezibotAngle() for how the current angle is measured.
+     * @see rotateLeft and \p rotateRight for the actual rotation implementations.
+     * @see EcpSignalDetection::measureDezibotAngle for how the current angle is measured.
      */
     void rotateToAngle(int goalAngle, int initialAngle);
 
     /**
      * @brief Rotate dezibot to the left for a specified duration.
      * 
-     * Use left motor of the dezibot (`dezibot.motion.left`).
+     * Use left motor of the dezibot (<tt>dezibot.motion.left<\tt>).
      * 
      * @param movementTime Duration for which the bot should rotate left, in
      *                     milliseconds.
@@ -143,7 +143,7 @@ private:
     /**
      * @brief Rotate dezibot to the right for a specified duration.
      * 
-     * Use left motor of the dezibot (`dezibot.motion.right`).
+     * Use left motor of the dezibot (<tt>dezibot.motion.right</tt>).
      * 
      * @param movementTime Duration for which the bot should rotate right, in
      *                     milliseconds.
@@ -173,7 +173,7 @@ private:
      *          Therefore, the angle is multiplied by 14 which approximates this
      *          assumption (180° * 28 = 5040 ms).
      * 
-     * @see rotateToAngle() for how this function is used in the context of
+     * @see rotateToAngle for how this function is used in the context of
      *      rotating the dezibot to a specific angle.
      * @see ROTATION_TIME_FACTOR for factor used to define linear relationship.
      */
@@ -185,12 +185,12 @@ private:
      * For example, if the initial infrared signal was 0°, then everything
      * in [-5°, 5°] will be accepted as an successful rotation.
      * 
-     * @see rotateToAngle() for usage.
+     * @see rotateToAngle for usage.
      */
     const int ROTATION_TOLERANCE = 5;
 
     /**
-     * @brief Maximum rotation iterations used in `turnLeft` and `turnRight`.
+     * @brief Maximum rotation iterations used in \p turnLeft` and \p turnRight.
      * 
      */
     const size_t MAX_ROTATION_ITERATIONS = 20;
@@ -198,7 +198,7 @@ private:
     /**
      * @brief Factor used to calculate rotation time.
      * 
-     * @see calculateRotationTime() for usage.
+     * @see calculateRotationTime for usage.
      * 
      */
     const float ROTATION_TIME_FACTOR = 28;

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -167,9 +167,9 @@ private:
      * @return uint Calculated rotation time (in milliseconds) rounded to the
      *              nearest integer.
      * 
-     * @details It is assumed that a 180° rotation takes about 2500 milliseconds
+     * @details It is assumed that a 180° rotation takes about 5000 milliseconds
      *          Therefore, the angle is multiplied by 14 which approximates this
-     *          assumption (180° * 14 = 2520 ms).
+     *          assumption (180° * 28 = 5040 ms).
      * 
      * @see rotateToAngle() for how this function is used in the context of
      *      rotating the dezibot to a specific angle.
@@ -181,11 +181,11 @@ private:
      * @brief Tolerance for a rotation to be accepted in degrees.
      * 
      * For example, if the initial infrared signal was 0°, then everything
-     * in [-10°, 10°] will be accepted as an successful rotation.
+     * in [-5°, 5°] will be accepted as an successful rotation.
      * 
      * @see rotateToAngle() for usage.
      */
-    const int ROTATION_TOLERANCE = 10;
+    const int ROTATION_TOLERANCE = 5;
 
     /**
      * @brief Maximum rotation iterations used in `turnLeft` and `turnRight`.
@@ -199,7 +199,7 @@ private:
      * @see calculateRotationTime() for usage.
      * 
      */
-    const float ROTATION_TIME_FACTOR = 14;
+    const float ROTATION_TIME_FACTOR = 28;
 };
 
 #endif // ECPMovement_h

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -23,7 +23,7 @@
 #define ROTATION_SPEED 8192
 #define ROTATION_CORRECTION_TIME 10000
 #define DEFAULT_MOVEMENT_CALIBRATION 3900
-#define MEASURING_DELAY 5
+#define MEASURING_DELAY 100
 
 class ECPMovement {
 public:
@@ -168,10 +168,7 @@ private:
      * @return uint Calculated rotation time (in milliseconds) rounded to the
      *              nearest integer.
      * 
-     * @details The rotation time is derived using a linear relationship. It is
-     *          assumed that a 180° rotation takes about 5000 milliseconds
-     *          Therefore, the angle is multiplied by 28 which approximates this
-     *          assumption (180° * 28 = 5040 ms).
+     * @details The rotation time is derived using a linear relationship.
      * 
      * @see rotateToAngle for how this function is used in the context of
      *      rotating the dezibot to a specific angle.
@@ -205,7 +202,7 @@ private:
      * @see calculateRotationTime for usage.
      * 
      */
-    static constexpr float ROTATION_TIME_FACTOR = 28;
+    static constexpr float ROTATION_TIME_FACTOR = 25;
 };
 
 #endif // ECPMovement_h

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -16,17 +16,13 @@
 
 #include "ECPChessLogic/ECPChessField.h"
 #include <ECPColorDetection/ECPColorDetection.h>
+#include <ECPSignalDetection/ECPSignalDetection.h>
 
 #define FORWARD_TIME 750
 #define MOVEMENT_BREAK 375
-
 #define ROTATION_SPEED 8192
-
-#define DEFAULT_MOVEMENT_CALIBRATION 3900
-#define DEFAULT_ROTATION_TIME_LEFT 2650
-#define DEFAULT_ROTATION_TIME_RIGHT 2875
-
 #define ROTATION_CORRECTION_TIME 10000
+#define DEFAULT_MOVEMENT_CALIBRATION 3900
 
 class ECPMovement {
 public:
@@ -35,14 +31,10 @@ public:
      * 
      * @param dezibot Dezibot to move
      * @param movementCalibration Base value to calibrate the dezibot's movement (default 3900)
-     * @param rotationTimeLeft Time needed for a 90 degree rotation anticlockwise (default 2650)
-     * @param rotationTimeRight Time needed for a 90 degree rotation clockwise (default 2875)
      */
     ECPMovement(
-        Dezibot &dezibot, 
-        uint movementCalibration = DEFAULT_MOVEMENT_CALIBRATION, 
-        uint rotationTimeLeft = DEFAULT_ROTATION_TIME_LEFT, 
-        uint rotationTimeRight = DEFAULT_ROTATION_TIME_RIGHT
+        Dezibot &dezibot,
+        uint movementCalibration = DEFAULT_MOVEMENT_CALIBRATION
     );
 
     /**
@@ -71,6 +63,7 @@ public:
 protected:
     Dezibot &dezibot;
     ECPColorDetection ecpColorDetection;
+    ECPSignalDetection ecpSignalDetection;
 
     /**
      * @brief Value to calibrate movement.
@@ -79,18 +72,6 @@ protected:
      * If the robot is just jumping up and down but not forward, try a lower value.
      */
     const uint movementCalibration;
-
-    /**
-     * @brief Time the dezibot needs for a 90 degree rotation anticlockwise.
-     * 
-     */
-    const uint rotationTimeLeft;
-
-    /**
-     * @brief Time the dezibot needs for a 90 degree rotation clockwise.
-     * 
-     */
-    const uint rotationTimeRight;
 
 private:
     /**
@@ -123,6 +104,102 @@ private:
         ECPChessField currentField, 
         ECPDirection intendedDirection
     );
+
+    /**
+     * @brief Rotate dezibot from measured initial angle to specified goal angle.
+     * 
+     * This function uses an incremental approach. Based on the difference of
+     * the two angles, incrementally rotate the bot toward the goal. Use
+     * the tolerance specified in `ROTATION_TOLERANCE`.
+     * 
+     * If the rotation could not be completed successfully after a certain
+     * amount of iterations (cf. `MAX_ROTATION_ITERATIONS`), print a statement
+     * on the display to request manual correction within 10 seconds before
+     * continuing.
+     * 
+     * @param goalAngle The target angle to which the dezibot is to rotated, in degrees.
+     * @param initialAngle Measured initial angle of the dezibot, in degrees.
+     * 
+     * @see calculateRotationTime() for details on how the rotation time is computed.
+     * @see rotateLeft() and rotateRight() for the actual rotation implementations.
+     * @see ecpSignalDetection.measureSignalAngle() for how the current angle is measured.
+     */
+    void rotateToAngle(int goalAngle, int initialAngle);
+
+    /**
+     * @brief Rotate dezibot to the left for a specified duration.
+     * 
+     * Use left motor of the dezibot (`dezibot.motion.left`).
+     * 
+     * @param movementTime Duration for which the bot should rotate left, in milliseconds.
+     * 
+     * @details This function is typically called as part of a larger rotation
+     *          mechanism, where the duration of the left rotation is calculated
+     *          based on the angle difference from the target position.
+     */
+    void rotateLeft(uint movementTime);
+
+    /**
+     * @brief Rotate dezibot to the right for a specified duration.
+     * 
+     * Use left motor of the dezibot (`dezibot.motion.right`).
+     * 
+     * @param movementTime Duration for which the bot should rotate right, in milliseconds.
+     * 
+     * @details This function is typically called as part of a larger rotation
+     *          mechanism, where the duration of the left rotation is calculated
+     *          based on the angle difference from the target position.
+     */
+    void rotateRight(uint movementTime);
+
+    /**
+     * @brief Calculate the time required to rotate based on the angle difference.
+     * 
+     * Compute the rotation time needed to adjust the dezibot's angle based on
+     * the difference between the current angle and the target angle.
+     * The calculation normalizes the angle difference to ensure it falls within
+     * the range of 0 to 180 degrees, and then derives the rotation time using
+     * a linear relationship.
+     *
+     * @param angleDifference Difference in angle between the current and target
+     *                        positions, in degrees.
+     *
+     * @return uint Calculated rotation time (in milliseconds) rounded to the
+     *              nearest integer.
+     * 
+     * @details It is assumed that a 180° rotation takes about 2500 milliseconds
+     *          Therefore, the angle is multiplied by 14 which approximates this
+     *          assumption (180° * 14 = 2520 ms).
+     * 
+     * @see rotateToAngle() for how this function is used in the context of
+     *      rotating the dezibot to a specific angle.
+     * @see ROTATION_TIME_FACTOR for factor used to define linear relationship.
+     */
+    uint calculateRotationTime(int angleDifference);
+
+    /**
+     * @brief Tolerance for a rotation to be accepted in degrees.
+     * 
+     * For example, if the initial infrared signal was 0°, then everything
+     * in [-10°, 10°] will be accepted as an successful rotation.
+     * 
+     * @see rotateToAngle() for usage.
+     */
+    const int ROTATION_TOLERANCE = 10;
+
+    /**
+     * @brief Maximum rotation iterations used in `turnLeft` and `turnRight`.
+     * 
+     */
+    const size_t MAX_ROTATION_ITERATIONS = 20;
+
+    /**
+     * @brief Factor used to calculate rotation time.
+     * 
+     * @see calculateRotationTime() for usage.
+     * 
+     */
+    const float ROTATION_TIME_FACTOR = 14;
 };
 
 #endif // ECPMovement_h

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -47,16 +47,24 @@ public:
     /**
      * @brief Turn 90 degrees left.
      * 
-     * @param currentField Field of the dezibot
-     * @param intendedDirection Direction the dezibot should look at after rotation
+     * @param currentField field of the dezibot
+     * @param intendedDirection direction the dezibot should look at after rotation
+     * 
+     * @details Uses \p ECPSignalDetection::measureDezibotAngle internally to
+     *          rotate dezibot to the correct angle. Make sure to place a
+     *          dezibot running <tt>examples/ir_emitter.ino</tt> within reach!
      */
     void turnLeft(ECPChessField currentField, ECPDirection intendedDirection);
 
     /**
      * @brief Turn 90 degrees right.
      * 
-     * @param currentField Field of the dezibot
-     * @param intendedDirection Direction the dezibot should look at after rotation
+     * @param currentField field of the dezibot
+     * @param intendedDirection direction the dezibot should look at after rotation
+     * 
+     * @details Uses \p ECPSignalDetection::measureDezibotAngle internally to
+     *          rotate dezibot to the correct angle. Make sure to place a
+     *          dezibot running <tt>examples/ir_emitter.ino</tt> within reach!
      */
     void turnRight(ECPChessField currentField, ECPDirection intendedDirection);
 
@@ -109,7 +117,7 @@ private:
      * @brief Rotate dezibot from measured initial angle to specified goal angle.
      * 
      * This function uses an incremental approach. Based on the difference of
-     * the two angles, incrementally rotate the bot toward the goal. Use
+     * the two angles, incrementally rotate the bot toward the goal, considering
      * the tolerance specified in \p ROTATION_TOLERANCE.
      * 
      * If the rotation could not be completed successfully after a certain
@@ -117,8 +125,9 @@ private:
      * on the display to request manual correction within 10 seconds before
      * continuing.
      * 
-     * @param goalAngle The target angle to which the dezibot is to rotated, in degrees.
-     * @param initialAngle Measured initial angle of the dezibot, in degrees.
+     * @param goalAngle The target angle to which the dezibot is to be rotated.
+     * @param initialAngle Measured initial angle of the dezibot, see
+     *                     \p EcpSignalDetection::measureDezibotAngle.
      * 
      * @see calculateRotationTime() for details on how the rotation time is computed.
      * @see rotateLeft and \p rotateRight for the actual rotation implementations.
@@ -127,30 +136,22 @@ private:
     void rotateToAngle(int goalAngle, int initialAngle);
 
     /**
-     * @brief Rotate dezibot to the left for a specified duration.
+     * @brief Rotate dezibot to the left (counter-clockwise) for a specified duration.
      * 
-     * Use left motor of the dezibot (<tt>dezibot.motion.left<\tt>).
-     * 
-     * @param movementTime Duration for which the bot should rotate left, in
+     * @param movementTime Duration for which the bot should rotate left in
      *                     milliseconds.
      * 
-     * @details This function is typically called as part of a larger rotation
-     *          mechanism, where the duration of the left rotation is calculated
-     *          based on the angle difference from the target position.
+     * @details Use right motor of the dezibot (<tt>dezibot.motion.right<\tt>).
      */
     void rotateLeft(uint movementTime);
 
     /**
-     * @brief Rotate dezibot to the right for a specified duration.
+     * @brief Rotate dezibot to the right (clockwise) for a specified duration.
      * 
-     * Use left motor of the dezibot (<tt>dezibot.motion.right</tt>).
-     * 
-     * @param movementTime Duration for which the bot should rotate right, in
+     * @param movementTime Duration for which the bot should rotate right in
      *                     milliseconds.
      * 
-     * @details This function is typically called as part of a larger rotation
-     *          mechanism, where the duration of the left rotation is calculated
-     *          based on the angle difference from the target position.
+     * @details Use left motor of the dezibot (<tt>dezibot.motion.left</tt>).
      */
     void rotateRight(uint movementTime);
 
@@ -159,9 +160,6 @@ private:
      * 
      * Compute the rotation time needed to adjust the dezibot's angle based on
      * the difference between the current angle and the target angle.
-     * The calculation normalizes the angle difference to ensure it falls within
-     * the range of 0 to 180 degrees, and then derives the rotation time using
-     * a linear relationship.
      *
      * @param angleDifference Difference in angle between the current and target
      *                        positions, in degrees.
@@ -169,8 +167,11 @@ private:
      * @return uint Calculated rotation time (in milliseconds) rounded to the
      *              nearest integer.
      * 
-     * @details It is assumed that a 180° rotation takes about 5000 milliseconds
-     *          Therefore, the angle is multiplied by 14 which approximates this
+     * @details The calculation normalizes the angle difference to ensure it
+     *          falls within the range of 0 to 180 degrees, and then derives the
+     *          rotation time using a linear relationship.
+     *          It is assumed that a 180° rotation takes about 5000 milliseconds
+     *          Therefore, the angle is multiplied by 28 which approximates this
      *          assumption (180° * 28 = 5040 ms).
      * 
      * @see rotateToAngle for how this function is used in the context of
@@ -183,17 +184,21 @@ private:
      * @brief Tolerance for a rotation to be accepted in degrees.
      * 
      * For example, if the initial infrared signal was 0°, then everything
-     * in [-5°, 5°] will be accepted as an successful rotation.
+     * in [-3°, 3°] will be accepted as an successful rotation.
+     * This is necessary to avoid unnecessary loops, e.g. if the infrared
+     * emitting dezibot is too far away.
      * 
      * @see rotateToAngle for usage.
      */
-    const int ROTATION_TOLERANCE = 5;
+    static const int ROTATION_TOLERANCE = 3;
 
     /**
-     * @brief Maximum rotation iterations used in \p turnLeft` and \p turnRight.
+     * @brief Maximum rotation iterations used in \p turnLeft and \p turnRight.
+     * 
+     * @see rotateToAngle for usage.
      * 
      */
-    const size_t MAX_ROTATION_ITERATIONS = 20;
+    static const size_t MAX_ROTATION_ITERATIONS = 20;
 
     /**
      * @brief Factor used to calculate rotation time.
@@ -201,7 +206,7 @@ private:
      * @see calculateRotationTime for usage.
      * 
      */
-    const float ROTATION_TIME_FACTOR = 28;
+    static constexpr float ROTATION_TIME_FACTOR = 28;
 };
 
 #endif // ECPMovement_h

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -122,19 +122,19 @@ private:
      * the tolerance specified in \p ROTATION_TOLERANCE.
      * 
      * If the rotation could not be completed successfully after a certain
-     * amount of iterations (cf. \p MAX_ROTATION_ITERATIONS), print a statement
-     * on the display to request manual correction within 10 seconds before
-     * continuing.
+     * amount of iterations (cf. \p MAX_ROTATION_ITERATIONS), return \p false.
      * 
      * @param goalAngle The target angle to which the dezibot is to be rotated.
      * @param initialAngle Measured initial angle of the dezibot, see
      *                     \p EcpSignalDetection::measureDezibotAngle.
      * 
+     * @return bool true if rotation was successful, false otherwise
+     * 
      * @see calculateRotationTime() for details on how the rotation time is computed.
      * @see rotateLeft and \p rotateRight for the actual rotation implementations.
      * @see EcpSignalDetection::measureDezibotAngle for how the current angle is measured.
      */
-    void rotateToAngle(int goalAngle, int initialAngle);
+    bool rotateToAngle(int goalAngle, int initialAngle);
 
     /**
      * @brief Rotate dezibot to the left (counter-clockwise) for a specified duration.

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -3,7 +3,7 @@
 ECPSignalDetection::ECPSignalDetection(Dezibot &dezibot)
     : dezibot(dezibot) {};
 
-float ECPSignalDetection::measureSignalAngle() {
+int ECPSignalDetection::measureSignalAngle() {
     const photoTransistors sensors[] = { IR_FRONT, IR_RIGHT, IR_BACK, IR_LEFT };
     float values[4] = {};
 
@@ -44,5 +44,5 @@ float ECPSignalDetection::measureSignalAngle() {
         angle += 360.0f;
     }
 
-    return angle;
+    return std::round(angle);
 };

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -32,6 +32,7 @@ int ECPSignalDetection::measureSignalAngle() {
         dezibot.display.println("No IR signal!");
         dezibot.display.println("Trying again...");
         delay(1000);
+        dezibot.display.clear();
         return measureSignalAngle();
     }
 

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -51,7 +51,7 @@ int ECPSignalDetection::measureSignalAngle() {
     if (roundedAngle < 0) {
         roundedAngle += 360;
     }
-    roundedAngle = roundedAngle % 360;
+    roundedAngle = (roundedAngle + 180) % 360;
 
     return roundedAngle;
 };

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -7,6 +7,7 @@ int ECPSignalDetection::measureSignalAngle() {
     const photoTransistors sensors[] = { IR_FRONT, IR_RIGHT, IR_BACK, IR_LEFT };
     float values[4] = {};
 
+    // measure all four IR signal values
     for (size_t i = 0; i < 4; i++) {
         const int irValue = dezibot.lightDetection.getAverageValue(
             sensors[i],
@@ -25,7 +26,7 @@ int ECPSignalDetection::measureSignalAngle() {
         }
     );
 
-    // recurse if no significant signal could be measured
+    // repeat if no sufficient signal could be measured
     if (!hasSignal) {
         dezibot.display.clear();
         dezibot.display.println("No IR signal!");
@@ -39,19 +40,17 @@ int ECPSignalDetection::measureSignalAngle() {
     const float south = values[2];
     const float west = values[3];
 
+    // calculate angle
     const float resultantNorthSouth = north - south;
     const float resultantEastWest = east - west;
-
     float angle = std::atan2(resultantEastWest, resultantNorthSouth);
     angle *= (180.0f / M_PI);   // convert from radian to degrees
 
     int roundedAngle = std::round(angle);
 
     // normalize angle to [0, 360]
-    roundedAngle = roundedAngle % 360;
-    if (roundedAngle < 0) {
-        roundedAngle += 360;
-    }
+    // add 360° before applying modulo to prevent negative values
+    roundedAngle = (roundedAngle + 360) % 360;
 
     return roundedAngle;
 };

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -1,0 +1,48 @@
+#include "ECPSignalDetection.h"
+
+ECPSignalDetection::ECPSignalDetection(Dezibot &dezibot)
+    : dezibot(dezibot) {};
+
+float ECPSignalDetection::measureSignalAngle() {
+    const photoTransistors sensors[] = { IR_FRONT, IR_RIGHT, IR_BACK, IR_LEFT };
+    float values[4] = {};
+
+    for (size_t i = 0; i < 4; i++) {
+        const int irValue = dezibot.lightDetection.getAverageValue(
+            sensors[i],
+            MEASUREMENT_COUNT,
+            TIME_BETWEEN_MEASUREMENTS
+        );
+        const float normalizedValue = dezibot.lightDetection.normalizeValue(irValue);
+        values[i] = normalizedValue;
+    }
+
+    bool hasSignal = std::any_of(
+        values, values+4,
+        [MIN_THRESHOLD_MEASUREMENTS](float value) {
+            return value > MIN_THRESHOLD_MEASUREMENTS;
+        }
+    );
+
+    if (!hasSignal) {
+        return -1.0f;
+    }
+
+    const float north = values[0];
+    const float east = values[1];
+    const float south = values[2];
+    const float west = values[3];
+
+    const float resultantNorthSouth = north - south;
+    const float resultantEastWest = east - west;
+
+    float angle = std::atan2(resultantEastWest, resultantNorthSouth);
+    angle *= (180.0f / M_PI);   // convert from radian to degrees
+    
+    // normalize angle to [0, 360]
+    if (angle < 0) {
+        angle += 360.0f;
+    }
+
+    return angle;
+};

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -48,10 +48,15 @@ int ECPSignalDetection::measureSignalAngle() {
     int roundedAngle = std::round(angle);
 
     // normalize angle to [0, 360]
+    roundedAngle = roundedAngle % 360;
     if (roundedAngle < 0) {
         roundedAngle += 360;
     }
-    roundedAngle = (roundedAngle + 180) % 360;
 
     return roundedAngle;
 };
+
+int ECPSignalDetection::measureDezibotAngle() {
+    int signalAngle = measureSignalAngle();
+    return (360 - signalAngle) % 360;
+}

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -42,9 +42,9 @@ int ECPSignalDetection::measureSignalAngle() {
     const float west = values[3];
 
     // calculate angle
-    const float resultantNorthSouth = north - south;
-    const float resultantEastWest = east - west;
-    float angle = std::atan2(resultantEastWest, resultantNorthSouth);
+    const float resultantX = east - west;
+    const float resultantY = north - south;
+    float angle = std::atan2(resultantX, resultantY);
     angle *= (180.0f / M_PI);   // convert from radian to degrees
 
     int roundedAngle = std::round(angle);

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -17,6 +17,7 @@ int ECPSignalDetection::measureSignalAngle() {
         values[i] = normalizedValue;
     }
 
+    // check if at least one of the measurements is above the threshold
     bool hasSignal = std::any_of(
         values, values+4,
         [MIN_THRESHOLD_MEASUREMENTS](float value) {
@@ -24,8 +25,13 @@ int ECPSignalDetection::measureSignalAngle() {
         }
     );
 
+    // recurse if no significant signal could be measured
     if (!hasSignal) {
-        return -1.0f;
+        dezibot.display.clear();
+        dezibot.display.println("No IR signal!");
+        dezibot.display.println("Trying again...");
+        delay(1000);
+        return measureSignalAngle();
     }
 
     const float north = values[0];
@@ -38,11 +44,14 @@ int ECPSignalDetection::measureSignalAngle() {
 
     float angle = std::atan2(resultantEastWest, resultantNorthSouth);
     angle *= (180.0f / M_PI);   // convert from radian to degrees
-    
-    // normalize angle to [0, 360]
-    if (angle < 0) {
-        angle += 360.0f;
-    }
 
-    return std::round(angle);
+    int roundedAngle = std::round(angle);
+
+    // normalize angle to [0, 360]
+    if (roundedAngle < 0) {
+        roundedAngle += 360;
+    }
+    roundedAngle = roundedAngle % 360;
+
+    return roundedAngle;
 };

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
@@ -33,9 +33,28 @@ public:
      *          signal could be detected! Make sure to place a dezibot running
      *          <tt>examples/ir_emitter.ino</tt> within reach.
      * 
+     * @attention This function measures the angle from which the <b>signal</b>
+     *            is coming from, <b>not</b> where the dezibot is facing. For,
+     *            refer to \p measureDezibotAngle.
+     * 
      * @return int Angle in degrees, i.e. [0, 360], if signal was detected.
      */
     int measureSignalAngle();
+
+    /**
+     * @brief Measure angle the dezibot is facing based on infrared signal.
+     * 
+     * @details Uses \p measureSignalAngle to get signal measurement.
+     * 
+     * @warning This function may <b>loop and never return</b> if no infrared
+     *          signal could be detected! Make sure to place a dezibot running
+     *          <tt>examples/ir_emitter.ino</tt> within reach.
+     * 
+     * @return int angle in which dezibot is facing.
+     * 
+     * @see measureSignalAngle for details on how IR signal is measured
+     */
+    int measureDezibotAngle();
 
 private:
     static const int MEASUREMENT_COUNT = 3;

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
@@ -34,8 +34,8 @@ public:
      *          <tt>examples/ir_emitter.ino</tt> within reach.
      * 
      * @attention This function measures the angle from which the <b>signal</b>
-     *            is coming from, <b>not</b> where the dezibot is facing. For,
-     *            refer to \p measureDezibotAngle.
+     *            is coming from, <b>not</b> where the dezibot is facing. For
+     *            that, refer to \p measureDezibotAngle.
      * 
      * @return int Angle in degrees, i.e. [0, 360], if signal was detected.
      */
@@ -57,8 +57,29 @@ public:
     int measureDezibotAngle();
 
 private:
+    /**
+     * @brief How many infrared signals are averaged in \p measureSignalAngle.
+     * 
+     */
     static const int MEASUREMENT_COUNT = 3;
-    static const int TIME_BETWEEN_MEASUREMENTS = 1; // in ms
+
+    /**
+     * @brief Time between measurements that are averaged to one in
+     *        \p measureSignalAngle in milliseconds,
+     * 
+     */
+    static const int TIME_BETWEEN_MEASUREMENTS = 1;
+
+    /**
+     * @brief Minimal threshold necessary to be measured before being discarded
+     *        as too weak.
+     * 
+     * Prevent interpreting signals that are not emitted by the IR emitting
+     * dezibot, caused, for example, by environmental influences.
+     * 
+     * @see measureSignalAngle for usage.
+     * 
+     */
     static constexpr float MIN_THRESHOLD_MEASUREMENTS = 0.10f;
 };
 

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
@@ -1,0 +1,40 @@
+/**
+ * @file ECPSignalDetection.h
+ * @author Ines Rohrbach, Nico Schramm
+ * @brief Helper class for IR signal detection
+ * @version 0.1
+ * @date 2025-02-09
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ */
+
+#ifndef ECPSignalDetection_H
+#define ECPSignalDetection_H
+
+#include <cmath>
+
+#include <Dezibot.h>
+
+class ECPSignalDetection{
+protected:
+    Dezibot &dezibot;
+
+public:
+    ECPSignalDetection(Dezibot &dezibot);
+
+    /**
+     * @brief Measure infrared signal angle where 0° is equivalent to north.
+     * 
+     * @return float Angle in degrees, i.e. [0, 360].
+     *               Returns -1 if no signal was detected or was too weak.
+     */
+    float measureSignalAngle();
+
+private:
+    static const int MEASUREMENT_COUNT = 3;
+    static const int TIME_BETWEEN_MEASUREMENTS = 1; // in ms
+    static constexpr float MIN_THRESHOLD_MEASUREMENTS = 0.10f;
+};
+
+#endif // ECPSignalDetection_H

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
@@ -26,8 +26,14 @@ public:
     /**
      * @brief Measure infrared signal angle where 0° is equivalent to north.
      * 
-     * @return int Angle in degrees, i.e. [0, 360].
-     *             Returns -1 if no signal was detected or was too weak.
+     * If no signal could be detected, print a corresponding info text on the
+     * dezibot's display, wait for 1 second and try again.
+     * 
+     * @warning This function may <b>loop and never return</b> if no infrared
+     *          signal could be detected! Make sure to place a dezibot running
+     *          <tt>examples/ir_emitter.ino</tt> within reach.
+     * 
+     * @return int Angle in degrees, i.e. [0, 360], if signal was detected.
      */
     int measureSignalAngle();
 

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
@@ -68,7 +68,7 @@ private:
      *        \p measureSignalAngle in milliseconds,
      * 
      */
-    static const int TIME_BETWEEN_MEASUREMENTS = 1;
+    static const int TIME_BETWEEN_MEASUREMENTS = 30;
 
     /**
      * @brief Minimal threshold necessary to be measured before being discarded

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
@@ -26,10 +26,10 @@ public:
     /**
      * @brief Measure infrared signal angle where 0° is equivalent to north.
      * 
-     * @return float Angle in degrees, i.e. [0, 360].
-     *               Returns -1 if no signal was detected or was too weak.
+     * @return int Angle in degrees, i.e. [0, 360].
+     *             Returns -1 if no signal was detected or was too weak.
      */
-    float measureSignalAngle();
+    int measureSignalAngle();
 
 private:
     static const int MEASUREMENT_COUNT = 3;

--- a/example/EmbeddedChessPieces/src/EmbeddedChessPieces.h
+++ b/example/EmbeddedChessPieces/src/EmbeddedChessPieces.h
@@ -15,5 +15,6 @@
 #include "ECPColorDetection/ECPColorDetection.h"
 #include "ECPChessLogic/ECPChessLogic.h"
 #include "ECPMovement/ECPMovement.h"
+#include "ECPSignalDetection/ECPSignalDetection.h"
 
 #endif // EmbeddedChessPieces_h

--- a/src/lightDetection/LightDetection.cpp
+++ b/src/lightDetection/LightDetection.cpp
@@ -51,16 +51,16 @@ photoTransistors LightDetection::getBrightest(ptType type){
     return maxSensor;
 };
 
-uint32_t LightDetection::getAverageValue(photoTransistors sensor, uint32_t measurments, uint32_t timeBetween){
+uint32_t LightDetection::getAverageValue(photoTransistors sensor, uint32_t measurements, uint32_t timeBetween){
     
     TickType_t xLastWakeTime = xTaskGetTickCount();
     TickType_t frequency = timeBetween / portTICK_PERIOD_MS;
     uint64_t cumulatedResult = 0; 
-    for(int i = 0; i < measurments; i++){
+    for(int i = 0; i < measurements; i++){
         cumulatedResult += LightDetection::getValue(sensor);
         xTaskDelayUntil(&xLastWakeTime,frequency);
     }
-    return cumulatedResult/measurments;
+    return cumulatedResult/measurements;
 };
 
 void LightDetection::beginInfrared(void){

--- a/src/lightDetection/LightDetection.cpp
+++ b/src/lightDetection/LightDetection.cpp
@@ -63,6 +63,10 @@ uint32_t LightDetection::getAverageValue(photoTransistors sensor, uint32_t measu
     return cumulatedResult/measurements;
 };
 
+float LightDetection::normalizeValue(uint32_t sensorValue, uint32_t maxValue) {
+    return ((float) sensorValue) / ((float) maxValue);
+}
+
 void LightDetection::beginInfrared(void){
     digitalWrite(IR_PT_ENABLE,true);
     pinMode(IR_PT_ENABLE, OUTPUT);

--- a/src/lightDetection/LightDetection.h
+++ b/src/lightDetection/LightDetection.h
@@ -1,6 +1,6 @@
 /**
  * @file LightDetection.h
- * @author Hans Haupt (hans.haupt@dezibot.de)
+ * @author Hans Haupt (hans.haupt@dezibot.de), Ines Rohrbach, Nico Schramm
  * @brief Class for Reading the values of the different Phototransistors, both IR, and DaylightSensors are supported. 
  * @version 0.1
  * @date 2024-04-26

--- a/src/lightDetection/LightDetection.h
+++ b/src/lightDetection/LightDetection.h
@@ -76,6 +76,15 @@ public:
      */
     static uint32_t getAverageValue(photoTransistors sensor, uint32_t measurements, uint32_t timeBetween);
 
+    /**
+     * @brief Get percentage of sensor value.
+     * 
+     * @param sensorValue raw value read by `getValue` or `getAverageValue`
+     * @param maxValue maximum value that can be reached; either configured or default (4095).
+     * @return float percentage of sensor value (0.0f to 1.0f)
+     */
+    static float normalizeValue(uint32_t sensorValue, uint32_t maxValue = MAX_SENSOR_VALUE);
+
 protected: 
     static const uint8_t IR_PT_FRONT_ADC = 3;
     static const uint8_t IR_PT_LEFT_ADC = 4;
@@ -87,6 +96,8 @@ protected:
 
     static const uint8_t DL_PT_ENABLE = 41;
     static const uint8_t IR_PT_ENABLE = 40;
+
+    static const uint16_t MAX_SENSOR_VALUE = 4095;
 
     
     static void beginInfrared(void);

--- a/src/lightDetection/LightDetection.h
+++ b/src/lightDetection/LightDetection.h
@@ -1,20 +1,19 @@
 /**
  * @file LightDetection.h
- * @author Hans Haupt (hans.haupt@dezibot.de)
+ * @author Hans Haupt (hans.haupt@dezibot.de), Ines Rohrbach, Nico Schramm
  * @brief Class for Reading the values of the different Phototransistors, both IR, and DaylightSensors are supported. 
- * @version 0.1
- * @date 2024-04-26
+ * @version 0.2
+ * @date 2025-01-21
  * 
- * @copyright Copyright (c) 2024
+ * @copyright Copyright (c) 2025
  * 
  */
 
 #ifndef LightDetection_h
 #define LightDetection_h
+
 #include <stdint.h>
 #include <Arduino.h>
-
-
 
 enum photoTransistors{
     IR_LEFT,
@@ -37,14 +36,15 @@ enum ptType{
     IR,
     DAYLIGHT
 };
+
 static const photoTransistors allIRPTs[] = {IR_FRONT,IR_LEFT,IR_RIGHT,IR_BACK};
-    static const photoTransistors allDLPTs[] = {DL_BOTTOM,DL_FRONT};
+static const photoTransistors allDLPTs[] = {DL_BOTTOM,DL_FRONT};
 
 
 class LightDetection{
 public: 
     /**
-     * @brief initialize the Lightdetection Compnent, must be called before the other methods are used.  
+     * @brief initialize the lightDetection component, must be called before the other methods are used.
      * 
      */
     static void begin(void);
@@ -59,7 +59,7 @@ public:
 
     /**
      * @brief can be used to determine which sensor is exposed to the greatest amount of light
-     * Can distingish between IR and Daylight 
+     * Can distinguish between IR and Daylight 
      * 
      * @param type select which PTTransistors to compare
      * @return photoTransistors which sensor is exposed to the greatest amount of light, if all sensor read 0, the front sensor is returned
@@ -67,14 +67,15 @@ public:
     static photoTransistors getBrightest(ptType type);
 
     /**
-     * @brief Get the Average of multiple measurments of a single PT 
+     * @brief Get the Average of multiple measurements of a single PT 
      * 
      * @param sensor Which Phototransistor should be read
-     * @param measurments how many measurements should be taken
+     * @param measurements how many measurements should be taken
      * @param timeBetween which time should elapse between
-     * @return the average of all taken meaurments
+     * @return the average of all taken measurements
      */
-    static uint32_t getAverageValue(photoTransistors sensor, uint32_t measurments, uint32_t timeBetween);
+    static uint32_t getAverageValue(photoTransistors sensor, uint32_t measurements, uint32_t timeBetween);
+
 protected: 
     static const uint8_t IR_PT_FRONT_ADC = 3;
     static const uint8_t IR_PT_LEFT_ADC = 4;

--- a/src/lightDetection/LightDetection.h
+++ b/src/lightDetection/LightDetection.h
@@ -1,11 +1,11 @@
 /**
  * @file LightDetection.h
- * @author Hans Haupt (hans.haupt@dezibot.de), Ines Rohrbach, Nico Schramm
+ * @author Hans Haupt (hans.haupt@dezibot.de)
  * @brief Class for Reading the values of the different Phototransistors, both IR, and DaylightSensors are supported. 
- * @version 0.2
- * @date 2025-01-21
+ * @version 0.1
+ * @date 2024-04-26
  * 
- * @copyright Copyright (c) 2025
+ * @copyright Copyright (c) 2024
  * 
  */
 


### PR DESCRIPTION
### Changes
- Add infrared signal measuring (`ECPSignalDetection`) and calculation of (relative) dezibot direction angle
- Add sketch for IR emitting and signal measuring
- Update rotation functions to use new incremental adaptive infrared-based algorithm, see `ECPMovement::turnLeft` / `ECPMovement::turnRight`
- Fix typos in `LightDetection`

### How to Test
- You need two dezibots to test this PR
- Run `ir_emitter.ino` on one and place it so that the side with only one leg faces in the middle of the board
- Run `move_to_90.ino` on a second dezibot
- Make sure to block any sun since this influences the IR measurements heavily

### Notes
- Note that the rotation is not ideal and still needs further improvements later on (separate ticket will be created). The offset of the sensor's placements from 90° will have to be considered.


Closes #31 