### PR TITLE
Add colour calibration and infrared colour detection.

### DIFF
--- a/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
+++ b/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
@@ -14,15 +14,14 @@
 #include <Wire.h>
 
 Dezibot dezibot = Dezibot();
-ECPColorDetection ecpColorDetection(dezibot);
+ECPSignalDetection ecpSignalDetection = ECPSignalDetection(dezibot);
+ECPColorDetection ecpColorDetection = ECPColorDetection(dezibot, ecpSignalDetection);
 
 void setup() {
   Serial.begin(9600);
   Serial.println("Started");
   dezibot.begin();
   Serial.println("Initialised");
-  
-  // ecpColorDetection.turnOnColorCorrectionLight();
 
   delay(3000);
   ecpColorDetection.calibrateFieldColor();

--- a/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
+++ b/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
@@ -21,15 +21,11 @@ void setup() {
   Serial.println("Started");
   dezibot.begin();
   Serial.println("Initialised");
-
-  bool hasStartedSuccessfully = dezibot.colorSensor.begin();
-  if(!hasStartedSuccessfully) {
-    Serial.println("ERROR: couldn't detect the sensor");
-    while(1) {}
-  }
-  delay(3000);
   
-  ecpColorDetection.turnOnColorCorrectionLight();
+  // ecpColorDetection.turnOnColorCorrectionLight();
+
+  delay(3000);
+  ecpColorDetection.calibrateFieldColor();
 }
 
 void loop() {

--- a/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
+++ b/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
@@ -93,13 +93,19 @@ void printFieldColor(FieldColor fieldColor) {
   String field = "";
   switch(fieldColor) {
     case WHITE_FIELD:
-      field = "white";
+      field = "w";
       break;
     case BLACK_FIELD:
-      field = "black";
+      field = "b";
       break;
-    case UNAMBIGUOUS_FIELD:
-      field = "unambiguous";
+    case UNAMBIGUOUS:
+      field = "u";
+      break;
+    case UNAMBIGUOUS_BLACK_TO_WHITE:
+      field = "bw";
+      break;
+    case UNAMBIGUOUS_WHITE_TO_BLACK:
+      field = "wb";
       break;
   }
   dezibot.display.println(field);

--- a/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
+++ b/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
@@ -77,14 +77,6 @@ void printValue(double colorValue, char* prefix) {
 /**
  * @brief Print formatted info for field color.
  * 
- * \code{.cpp}
- * printIsWhiteField(true)
- * // "F W"
- * 
- * printIsWhiteField(false)
- * \endcode
- * ```
- * 
  * @param fieldColor Determined FieldColor
  */
 void printFieldColor(FieldColor fieldColor) {
@@ -100,12 +92,6 @@ void printFieldColor(FieldColor fieldColor) {
       break;
     case UNAMBIGUOUS:
       field = "u";
-      break;
-    case UNAMBIGUOUS_BLACK_TO_WHITE:
-      field = "bw";
-      break;
-    case UNAMBIGUOUS_WHITE_TO_BLACK:
-      field = "wb";
       break;
   }
   dezibot.display.println(field);

--- a/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
+++ b/example/EmbeddedChessPieces/examples/colour_detection/colour_detection.ino
@@ -38,7 +38,7 @@ void loop() {
   // double cct = dezibot.colorSensor.getCCT();
 
   double brightness = dezibot.colorSensor.calculateBrightness(red, green, blue);
-  bool isWhite = ecpColorDetection.isWhiteField();
+  FieldColor color = ecpColorDetection.getFieldColor();
 
   Serial.println("");
   dezibot.display.clear();
@@ -51,7 +51,7 @@ void loop() {
   // printValue(cct, "C");
   printValue(ambient, "A");
   printValue(brightness, "H");
-  printIsWhiteField(isWhite);
+  printFieldColor(color);
 
   delay(500);
 }
@@ -75,7 +75,7 @@ void printValue(double colorValue, char* prefix) {
 }
 
 /**
- * @brief Print formatted info for isWhiteField.
+ * @brief Print formatted info for field color.
  * 
  * \code{.cpp}
  * printIsWhiteField(true)
@@ -85,12 +85,23 @@ void printValue(double colorValue, char* prefix) {
  * \endcode
  * ```
  * 
- * @param isWhiteField true if is white, false otherwise
+ * @param fieldColor Determined FieldColor
  */
-void printIsWhiteField(bool isWhiteField) {
+void printFieldColor(FieldColor fieldColor) {
   dezibot.display.print("F ");
   Serial.print("F ");
-  String field = isWhiteField ? "W" : "B";
+  String field = "";
+  switch(fieldColor) {
+    case WHITE_FIELD:
+      field = "white";
+      break;
+    case BLACK_FIELD:
+      field = "black";
+      break;
+    case UNAMBIGUOUS_FIELD:
+      field = "unambiguous";
+      break;
+  }
   dezibot.display.println(field);
   Serial.println(field);
 }

--- a/example/EmbeddedChessPieces/examples/ir_sensors/ir_color_detection/ir_color_detection.ino
+++ b/example/EmbeddedChessPieces/examples/ir_sensors/ir_color_detection/ir_color_detection.ino
@@ -1,0 +1,42 @@
+/**
+ * @file ir_color_detection.ino
+ * @author Ines Rohrbach, Nico Schramm
+ * @brief Example to determine if Dezibot is on white or black surface using infrared
+ * @version 0.1
+ * @date 2025-03-21
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ */
+
+#include <Dezibot.h>
+#include <EmbeddedChessPieces.h>
+#include <Wire.h>
+
+#define BAUD_RATE 9600
+
+Dezibot dezibot = Dezibot();
+ECPSignalDetection ecpSignalDetection = ECPSignalDetection(dezibot);
+ECPColorDetection ecpColorDetection = ECPColorDetection(dezibot, ecpSignalDetection);
+
+void setup() {
+   Serial.begin(BAUD_RATE);
+   dezibot.begin();
+   delay(500);
+
+   dezibot.display.flipOrientation();
+
+   // select infrared as color detection mode
+   ecpColorDetection.setColorDetectionMode(true);
+   ecpColorDetection.calibrateIRFieldColor();
+}
+
+void loop() {
+    FieldColor fieldColor = ecpColorDetection.getFieldColor();
+
+    dezibot.display.clear();
+    dezibot.display.println(fieldColor);
+
+    delay(500);
+}
+ 

--- a/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
+++ b/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
@@ -22,6 +22,8 @@ void setup() {
     Serial.begin(BAUD_RATE);
     dezibot.begin();
     delay(500);
+    ecpMovement.getECPColorDetection()->setShouldTurnOnColorCorrectionLight(true);
+    ecpMovement.getECPColorDetection()->calibrateFieldColor();
 }
 
 void loop() {

--- a/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
+++ b/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
@@ -24,9 +24,8 @@ void setup() {
     delay(500);
     
     dezibot.display.flipOrientation();
-    ecpMovement.getECPColorDetection()->setShouldTurnOnColorCorrectionLight(true);
-    ecpMovement.getECPColorDetection()->turnOnColorCorrectionLight();
-    ecpMovement.getECPColorDetection()->calibrateFieldColor();
+    ecpMovement.setShouldTurnOnColorCorrectionLight(true);
+    ecpMovement.calibrateFieldColor();
 }
 
 void loop() {

--- a/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
+++ b/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
@@ -22,7 +22,10 @@ void setup() {
     Serial.begin(BAUD_RATE);
     dezibot.begin();
     delay(500);
+    
+    dezibot.display.flipOrientation();
     ecpMovement.getECPColorDetection()->setShouldTurnOnColorCorrectionLight(true);
+    ecpMovement.getECPColorDetection()->turnOnColorCorrectionLight();
     ecpMovement.getECPColorDetection()->calibrateFieldColor();
 }
 

--- a/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
+++ b/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
@@ -24,8 +24,14 @@ void setup() {
     delay(500);
     
     dezibot.display.flipOrientation();
-    ecpMovement.setShouldTurnOnColorCorrectionLight(true);
-    ecpMovement.calibrateFieldColor();
+
+    // color sensor
+    // ecpMovement.setShouldTurnOnColorCorrectionLight(true);
+    // ecpMovement.calibrateFieldColor();
+
+    // infrared
+    ecpMovement.setColorDetectionMode(true);
+    ecpMovement.calibrateIRFieldColor();
 }
 
 void loop() {

--- a/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
+++ b/example/EmbeddedChessPieces/examples/movement/move_to_field/move_to_field.ino
@@ -42,8 +42,8 @@ void loop() {
 void iteration(bool isWhite) {
     dezibot.display.clear();
     const String color = isWhite ? "white" : "black";
-    dezibot.display.println("Prepare " + color +  "\nYou've got \n10 seconds...");
-    delay(10000);
+    dezibot.display.println("Prepare " + color +  "\nYou've got \n5 seconds...");
+    delay(5000);
 
     const String prefix = isWhite ? "White" : "Black";
     dezibot.display.println(prefix + " queen...");

--- a/example/EmbeddedChessPieces/examples/movement/walk_straight/walk_straight.ino
+++ b/example/EmbeddedChessPieces/examples/movement/walk_straight/walk_straight.ino
@@ -18,7 +18,6 @@
 
 Dezibot dezibot = Dezibot();
 ECPMovement ecpMovement(dezibot, MOVEMENT_CALIBRATION);
-ECPColorDetection ecpColorDetection(dezibot);
 
 void setup() {
   Serial.begin(9600);
@@ -28,7 +27,14 @@ void setup() {
 
   // initial delay to mitigate faulty color sensor readings
   delay(1000);
-  ecpColorDetection.turnOnColorCorrectionLight();
+
+  // color sensor
+  // ecpMovement.setShouldTurnOnColorCorrectionLight(true);
+  // ecpMovement.calibrateFieldColor();
+  
+  // infrared
+  ecpMovement.setColorDetectionMode(true);
+  ecpMovement.calibrateIRFieldColor();
 }
 
 void loop() {

--- a/example/EmbeddedChessPieces/examples/movement/walk_straight/walk_straight.ino
+++ b/example/EmbeddedChessPieces/examples/movement/walk_straight/walk_straight.ino
@@ -36,7 +36,7 @@ void loop() {
     dezibot.display.print("Moving ");
     dezibot.display.print(numberOfFields);
     dezibot.display.println(" Fields");
-    ecpMovement.move(numberOfFields);
+    ecpMovement.move(numberOfFields, {A, (1 + numberOfFields)}, NORTH);
 
     dezibot.display.println("\nDone");
     delay(10000);

--- a/example/EmbeddedChessPieces/src/ECPChessLogic/ECPChessPiece.cpp
+++ b/example/EmbeddedChessPieces/src/ECPChessLogic/ECPChessPiece.cpp
@@ -188,9 +188,6 @@ void ECPChessPiece::setRedLight(bool shouldEnable) {
         dezibot.multiColorLight.setLed(BOTTOM, red);
     } else {
         dezibot.multiColorLight.turnOffLed(BOTTOM);
-        if (ecpMovement.getECPColorDetection()->getShouldTurnOnColorCorrectionLight()) {
-            ecpMovement.getECPColorDetection()->turnOnColorCorrectionLight();
-        }
     }
 };
 
@@ -200,8 +197,5 @@ void ECPChessPiece::setGreenLight(bool shouldEnable) {
         dezibot.multiColorLight.setLed(BOTTOM, green);
     } else {
         dezibot.multiColorLight.turnOffLed(BOTTOM);
-        if (ecpMovement.getECPColorDetection()->getShouldTurnOnColorCorrectionLight()) {
-            ecpMovement.getECPColorDetection()->turnOnColorCorrectionLight();
-        }
     }
 };

--- a/example/EmbeddedChessPieces/src/ECPChessLogic/ECPChessPiece.cpp
+++ b/example/EmbeddedChessPieces/src/ECPChessLogic/ECPChessPiece.cpp
@@ -91,7 +91,7 @@ void ECPChessPiece::moveHorizontally(int fieldsToMove) {
     currentDirection = newDirection;
     ecpMovement.move(
         abs(fieldsToMove), 
-        {(ECPBoardColumn) (currentField.column + fieldsToMove), currentField.row},
+        {(ECPBoardColumn) (currentField.column - fieldsToMove), currentField.row},
         currentDirection
     );
     drawFigureToDisplay();
@@ -138,7 +138,7 @@ void ECPChessPiece::moveVertically(int fieldsToMove) {
     currentDirection = newDirection;
     ecpMovement.move(
         abs(fieldsToMove),
-        {currentField.column, currentField.row + fieldsToMove},
+        {currentField.column, currentField.row - fieldsToMove},
         currentDirection
     );
     drawFigureToDisplay();

--- a/example/EmbeddedChessPieces/src/ECPChessLogic/ECPChessPiece.cpp
+++ b/example/EmbeddedChessPieces/src/ECPChessLogic/ECPChessPiece.cpp
@@ -89,7 +89,12 @@ void ECPChessPiece::moveHorizontally(int fieldsToMove) {
     }
 
     currentDirection = newDirection;
-    ecpMovement.move(abs(fieldsToMove));
+    ecpMovement.move(
+        abs(fieldsToMove), 
+        {(ECPBoardColumn) (currentField.column + fieldsToMove), currentField.row},
+        currentDirection
+    );
+    drawFigureToDisplay();
 };
 
 void ECPChessPiece::moveVertically(int fieldsToMove) {
@@ -131,7 +136,12 @@ void ECPChessPiece::moveVertically(int fieldsToMove) {
     }
 
     currentDirection = newDirection;
-    ecpMovement.move(abs(fieldsToMove));
+    ecpMovement.move(
+        abs(fieldsToMove),
+        {currentField.column, currentField.row + fieldsToMove},
+        currentDirection
+    );
+    drawFigureToDisplay();
 };
 
 void ECPChessPiece::turnBackToInitialDirection() {

--- a/example/EmbeddedChessPieces/src/ECPChessLogic/ECPChessPiece.cpp
+++ b/example/EmbeddedChessPieces/src/ECPChessLogic/ECPChessPiece.cpp
@@ -178,6 +178,9 @@ void ECPChessPiece::setRedLight(bool shouldEnable) {
         dezibot.multiColorLight.setLed(BOTTOM, red);
     } else {
         dezibot.multiColorLight.turnOffLed(BOTTOM);
+        if (ecpMovement.getECPColorDetection()->getShouldTurnOnColorCorrectionLight()) {
+            ecpMovement.getECPColorDetection()->turnOnColorCorrectionLight();
+        }
     }
 };
 
@@ -187,5 +190,8 @@ void ECPChessPiece::setGreenLight(bool shouldEnable) {
         dezibot.multiColorLight.setLed(BOTTOM, green);
     } else {
         dezibot.multiColorLight.turnOffLed(BOTTOM);
+        if (ecpMovement.getECPColorDetection()->getShouldTurnOnColorCorrectionLight()) {
+            ecpMovement.getECPColorDetection()->turnOnColorCorrectionLight();
+        }
     }
 };

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
@@ -25,12 +25,7 @@ void ECPColorDetection::calibrateFieldColor() {
 };
 
 FieldColor ECPColorDetection::getFieldColor() {
-    const double ambient = dezibot.colorSensor.getNormalizedAmbientValue();
-    double red = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::RED, ambient);
-    double green = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::GREEN, ambient);
-    double blue = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::BLUE, ambient);
-
-    const double brightness = dezibot.colorSensor.calculateBrightness(red, green, blue);
+    const double brightness = measureBrightness();
 
     if (isWhiteFieldTopThreshold <= brightness) {
         return UNAMBIGUOUS_BLACK_TO_WHITE;
@@ -49,7 +44,6 @@ FieldColor ECPColorDetection::getFieldColor() {
 
 void ECPColorDetection::setShouldTurnOnColorCorrectionLight(bool turnOn) {
     shouldTurnOnColorCorrectionLight = turnOn;
-    turnOn ? turnOnColorCorrectionLight() : turnOffColorCorrectionLight();
 }
 
 bool ECPColorDetection::getShouldTurnOnColorCorrectionLight() {
@@ -75,13 +69,23 @@ double ECPColorDetection::calibrateColor(bool isWhite) {
     dezibot.display.clear();
     dezibot.display.println(request);
     delay(CALIBRATION_TIME);
+    dezibot.display.clear();
 
-    double ambient = dezibot.colorSensor.getNormalizedAmbientValue();
+    return measureBrightness();
+};
+
+double ECPColorDetection::measureBrightness() {
+    if (shouldTurnOnColorCorrectionLight) {
+        turnOnColorCorrectionLight();
+        delay(DELAY_BEFORE_MEASURING);
+    }
+
+    const double ambient = dezibot.colorSensor.getNormalizedAmbientValue();
     double red = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::RED, ambient);
     double green = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::GREEN, ambient);
     double blue = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::BLUE, ambient);
-    dezibot.display.clear();
 
-    double brightness = dezibot.colorSensor.calculateBrightness(red, green, blue);
-    return brightness;
+    turnOffColorCorrectionLight();
+
+    return dezibot.colorSensor.calculateBrightness(red, green, blue);
 };

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
@@ -32,6 +32,7 @@ FieldColor ECPColorDetection::getFieldColor() {
 
 void ECPColorDetection::setShouldTurnOnColorCorrectionLight(bool turnOn) {
     shouldTurnOnColorCorrectionLight = turnOn;
+    turnOn ? turnOnColorCorrectionLight() : turnOffColorCorrectionLight();
 }
 
 bool ECPColorDetection::getShouldTurnOnColorCorrectionLight() {

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
@@ -7,10 +7,21 @@ void ECPColorDetection::calibrateFieldColor() {
     double blackBrightness = calibrateColor(false);
 
     double diff = whiteBrightness - blackBrightness;
-    double offset = diff * 0.3; // placeholder
+    double offset = diff * 0.025; // placeholder
 
-    isWhiteFieldThreshold = whiteBrightness - offset;
-    isBlackFieldThreshold = blackBrightness + offset;
+    isWhiteFieldTopThreshold = whiteBrightness + offset;
+    isWhiteFieldBottomThreshold = whiteBrightness - offset;
+    isBlackFieldTopThreshold = blackBrightness + offset;
+    isBlackFieldBottomThreshold = blackBrightness - offset;
+    //debug
+    dezibot.display.clear();
+    dezibot.display.println(isWhiteFieldTopThreshold);
+    dezibot.display.println(whiteBrightness);
+    dezibot.display.println(isWhiteFieldBottomThreshold);
+    dezibot.display.println(isBlackFieldTopThreshold);
+    dezibot.display.println(blackBrightness);
+    dezibot.display.println(isBlackFieldBottomThreshold);
+    delay(7500);
 };
 
 FieldColor ECPColorDetection::getFieldColor() {
@@ -21,13 +32,19 @@ FieldColor ECPColorDetection::getFieldColor() {
 
     const double brightness = dezibot.colorSensor.calculateBrightness(red, green, blue);
 
-    if (brightness >= isWhiteFieldThreshold) {
+    if (isWhiteFieldTopThreshold <= brightness) {
+        return UNAMBIGUOUS_BLACK_TO_WHITE;
+    }
+    if ((isWhiteFieldBottomThreshold <= brightness) && ((brightness < isWhiteFieldTopThreshold))) {
         return WHITE_FIELD;
     }
-    if (brightness <= isBlackFieldThreshold) {
+    if ((isBlackFieldBottomThreshold < brightness) && ((brightness <= isBlackFieldTopThreshold))) {
         return BLACK_FIELD;
     }
-    return UNAMBIGUOUS_FIELD;
+    if (brightness <= isBlackFieldBottomThreshold) {
+        return UNAMBIGUOUS_WHITE_TO_BLACK;
+    }
+    return UNAMBIGUOUS;
 };
 
 void ECPColorDetection::setShouldTurnOnColorCorrectionLight(bool turnOn) {

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
@@ -2,6 +2,17 @@
 
 ECPColorDetection::ECPColorDetection(Dezibot &d) : dezibot(d) {};
 
+void ECPColorDetection::calibrateFieldColor() {
+    double whiteBrightness = calibrateColor(true);
+    double blackBrightness = calibrateColor(false);
+
+    double diff = whiteBrightness - blackBrightness;
+    double offset = diff * 0.8; // placeholder
+
+    isWhiteFieldThreshold = whiteBrightness - offset;
+    isBlackFieldThreshold = blackBrightness + offset;
+};
+
 bool ECPColorDetection::isWhiteField() {
     double ambient = dezibot.colorSensor.getNormalizedAmbientValue();
     double red = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::RED, ambient);
@@ -10,7 +21,7 @@ bool ECPColorDetection::isWhiteField() {
 
     double brightness = dezibot.colorSensor.calculateBrightness(red, green, blue);
 
-    return brightness >= IS_WHITE_FIELD_THRESHOLD;
+    return brightness >= isWhiteFieldThreshold;
 };
 
 void ECPColorDetection::turnOnColorCorrectionLight() {
@@ -23,4 +34,22 @@ void ECPColorDetection::turnOnColorCorrectionLight() {
 
 void ECPColorDetection::turnOffColorCorrectionLight() {
     dezibot.multiColorLight.turnOffLed(BOTTOM);
+};
+
+double ECPColorDetection::calibrateColor(bool isWhite) {
+    String color = isWhite ? "white" : "black";
+    String request = "Calibrate " + color + "\nPlease place on\n" + color + 
+        " field\nin " + String(CALIBRATION_TIME/1000) + " seconds";
+    dezibot.display.clear();
+    dezibot.display.println(request);
+    delay(CALIBRATION_TIME);
+
+    double ambient = dezibot.colorSensor.getNormalizedAmbientValue();
+    double red = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::RED, ambient);
+    double green = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::GREEN, ambient);
+    double blue = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::BLUE, ambient);
+    dezibot.display.clear();
+
+    double brightness = dezibot.colorSensor.calculateBrightness(red, green, blue);
+    return brightness;
 };

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
@@ -103,17 +103,14 @@ double ECPColorDetection::calibrateColor(bool isWhite) {
 int ECPColorDetection::calibrateIRColor(bool isWhite) {
     const String color = isWhite ? "white" : "black";
     const String request = "Calibrate " + color + "\nPlease place on\n" + color
-        + " field\nin " + String((CALIBRATION_TIME + 1000) / 1000) + " seconds"; // TODO: use constant
+        + " field\nin " + String((CALIBRATION_TIME) / 1000) + " seconds"; // TODO: use constant
     dezibot.display.clear();
     dezibot.display.println(request);
-    delay(CALIBRATION_TIME + 1000);
+    delay(CALIBRATION_TIME);
     
-    dezibot.infraredLight.bottom.turnOn();
-    delay(1000); // delay for infrared
-
     const int irValue = ecpSignalDetection.cumulateInfraredValues();
 
-    dezibot.infraredLight.bottom.turnOff();
+    // clear display after measuring irValue
     dezibot.display.clear();
 
     return irValue;
@@ -179,15 +176,7 @@ FieldColor ECPColorDetection::calculateLikelyFieldColor() {
 };
 
 FieldColor ECPColorDetection::measureInfraredFieldColor() {
-    // TODO: test if it works with 500, and make delays constants
-    delay(1000); // delay for infrared
-
-    dezibot.infraredLight.bottom.turnOn();
-    delay(1000); // delay for infrared
-
     const int irValue = ecpSignalDetection.cumulateInfraredValues();
-
-    dezibot.infraredLight.bottom.turnOff();
 
     if (isIRWhiteFieldThreshold < irValue) {
         return WHITE_FIELD;
@@ -200,14 +189,7 @@ FieldColor ECPColorDetection::measureInfraredFieldColor() {
 };
 
 FieldColor ECPColorDetection::calculateLikelyInfraredFieldColor() {
-    delay(1000); // delay for infrared
-
-    dezibot.infraredLight.bottom.turnOn();
-    delay(1000); // delay for infrared
-
     const int irValue = ecpSignalDetection.cumulateInfraredValues();
-
-    dezibot.infraredLight.bottom.turnOff();
 
     int diffToWhite = std::abs(isIRWhiteFieldThreshold - irValue);
     int diffToBlack = std::abs(irValue - isBlackFieldThreshold);

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
@@ -7,21 +7,27 @@ void ECPColorDetection::calibrateFieldColor() {
     double blackBrightness = calibrateColor(false);
 
     double diff = whiteBrightness - blackBrightness;
-    double offset = diff * 0.8; // placeholder
+    double offset = diff * 0.3; // placeholder
 
     isWhiteFieldThreshold = whiteBrightness - offset;
     isBlackFieldThreshold = blackBrightness + offset;
 };
 
-bool ECPColorDetection::isWhiteField() {
-    double ambient = dezibot.colorSensor.getNormalizedAmbientValue();
+FieldColor ECPColorDetection::getFieldColor() {
+    const double ambient = dezibot.colorSensor.getNormalizedAmbientValue();
     double red = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::RED, ambient);
     double green = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::GREEN, ambient);
     double blue = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::BLUE, ambient);
 
-    double brightness = dezibot.colorSensor.calculateBrightness(red, green, blue);
+    const double brightness = dezibot.colorSensor.calculateBrightness(red, green, blue);
 
-    return brightness >= isWhiteFieldThreshold;
+    if (brightness >= isWhiteFieldThreshold) {
+        return WHITE_FIELD;
+    }
+    if (brightness <= isBlackFieldThreshold) {
+        return BLACK_FIELD;
+    }
+    return UNAMBIGUOUS_FIELD;
 };
 
 void ECPColorDetection::turnOnColorCorrectionLight() {

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
@@ -6,13 +6,13 @@ void ECPColorDetection::calibrateFieldColor() {
     double whiteBrightness = calibrateColor(true);
     double blackBrightness = calibrateColor(false);
 
-    double diff = whiteBrightness - blackBrightness;
-    double offset = diff * 0.025; // placeholder
+    double offsetWhite = whiteBrightness * 0.0075; // placeholder
+    double offsetBlack = blackBrightness * 0.075; // placeholder
 
-    isWhiteFieldTopThreshold = whiteBrightness + offset;
-    isWhiteFieldBottomThreshold = whiteBrightness - offset;
-    isBlackFieldTopThreshold = blackBrightness + offset;
-    isBlackFieldBottomThreshold = blackBrightness - offset;
+    isWhiteFieldTopThreshold = std::min(whiteBrightness + offsetWhite, 254.9);
+    isWhiteFieldBottomThreshold = whiteBrightness - 2*offsetWhite;
+    isBlackFieldTopThreshold = blackBrightness + 2*offsetBlack;
+    isBlackFieldBottomThreshold = std::max(blackBrightness - offsetBlack, 0.1);
     //debug
     dezibot.display.clear();
     dezibot.display.println(isWhiteFieldTopThreshold);
@@ -85,7 +85,7 @@ double ECPColorDetection::measureBrightness() {
     double green = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::GREEN, ambient);
     double blue = dezibot.colorSensor.getNormalizedColorValue(ColorSensor::BLUE, ambient);
 
-    turnOffColorCorrectionLight();
+    // turnOffColorCorrectionLight();
 
     return dezibot.colorSensor.calculateBrightness(red, green, blue);
 };

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.cpp
@@ -30,6 +30,14 @@ FieldColor ECPColorDetection::getFieldColor() {
     return UNAMBIGUOUS_FIELD;
 };
 
+void ECPColorDetection::setShouldTurnOnColorCorrectionLight(bool turnOn) {
+    shouldTurnOnColorCorrectionLight = turnOn;
+}
+
+bool ECPColorDetection::getShouldTurnOnColorCorrectionLight() {
+    return shouldTurnOnColorCorrectionLight;
+}
+
 void ECPColorDetection::turnOnColorCorrectionLight() {
     uint32_t colorCorrectionWhite = dezibot.multiColorLight.color(
         COLOR_CORRECTION_LIGHT_R,

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
@@ -20,22 +20,30 @@
 
 #define CALIBRATION_TIME 5000
 
+/**
+ * @brief Color of field the dezibot is standing on.
+ * 
+ * Convertible to int, i.e. UNAMBIGUOUS == 0, BLACK == 1, WHITE == 2
+ * 
+ */
+enum FieldColor {
+    UNAMBIGUOUS_FIELD, BLACK_FIELD, WHITE_FIELD
+};
+
 class ECPColorDetection {
 public:
     ECPColorDetection(Dezibot &d);
 
     /**
-     * @brief Determine if brightness value represents a white or a black chess
+     * @brief Determine if brightness value clearly represents a white or a black chess
      *        field.
      *
-     * Note that the room must be well-lit or color correction light is turned on
-     * (see \see turnOnColorCorrectionLight).
-     * At a normalized ambient light of about 10.0 or lower white field will be interpreted as black.
+     * Note that the field color detection should be calibrated.
+     * @see calibrateFieldColor() 
      * 
-     * @return true if surface is white-ish
-     * @return false if surface is black-ish
+     * @return Determined field color
      */
-    bool isWhiteField();
+    FieldColor getFieldColor();
 
     /**
      * @brief Turn on the LED on the bottom of the Dezibot.

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
@@ -14,6 +14,8 @@
 
 #include <Dezibot.h>
 
+#define DELAY_BEFORE_MEASURING 5
+
 #define COLOR_CORRECTION_LIGHT_R 43
 #define COLOR_CORRECTION_LIGHT_G 33
 #define COLOR_CORRECTION_LIGHT_B 35
@@ -55,9 +57,6 @@ public:
 
     /**
      * @brief Set value for shouldTurnOnColorCorrectionLight flag
-     * 
-     * Turn on color correction light if parameter turnOn is true and
-     * turn off color correction light if parameter is false
      * 
      * @param turnOn true if correction light should be turned on else false 
      */
@@ -130,6 +129,13 @@ private:
      * @return brightness as double 
      */
     double calibrateColor(bool isWhite);
+
+    /**
+     * @brief Measure brightness
+     * 
+     * @return brightness as double
+     */
+    double measureBrightness();
 };
 
 #endif // ECPColorDetection_h

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
@@ -14,17 +14,9 @@
 
 #include <Dezibot.h>
 
-#define DELAY_BEFORE_MEASURING 20
-
 #define COLOR_CORRECTION_LIGHT_R 43
 #define COLOR_CORRECTION_LIGHT_G 33
 #define COLOR_CORRECTION_LIGHT_B 35
-
-#define CALIBRATION_TIME 5000
-#define DEFAULT_TOP_WHITE_THRESHOLD 248.0
-#define DEFAULT_BOTTOM_WHITE_THRESHOLD 245.0
-#define DEFAULT_TOP_BLACK_THRESHOLD 48.0
-#define DEFAULT_BOTTOM_BLACK_THRESHOLD 42.0
 
 /**
  * @brief Color of field the dezibot is standing on.
@@ -35,8 +27,6 @@
 enum FieldColor {
     BLACK_FIELD, 
     WHITE_FIELD,
-    UNAMBIGUOUS_WHITE_TO_BLACK, 
-    UNAMBIGUOUS_BLACK_TO_WHITE,
     UNAMBIGUOUS
 };
 
@@ -56,14 +46,26 @@ public:
     FieldColor getFieldColor();
 
     /**
-     * @brief Set value for shouldTurnOnColorCorrectionLight flag
+     * @brief Determine likely field color.
+     * 
+     * Usecase: the determined field color is unambiguous but a likely color is need
+     * 
+     * Determine if measured brightness is closer to the black or white field threshold
+     * In case the distance is identical black field is preferred
+     * 
+     * @return Likely fieldColor, only BLACK_FIELD and WHITE_FIELD possible
+     */
+    FieldColor getLikelyFieldColor();
+
+    /**
+     * @brief Set value for shouldTurnOnColorCorrectionLight flag.
      * 
      * @param turnOn true if correction light should be turned on else false 
      */
     void setShouldTurnOnColorCorrectionLight(bool turnOn);
 
     /**
-     * @brief Return value of shouldTurnOnColorCorrectionLight flag
+     * @brief Return value of shouldTurnOnColorCorrectionLight flag.
      * 
      * @return @see shouldTurnOnColorCorrectionLight
      */
@@ -83,7 +85,7 @@ public:
     void turnOffColorCorrectionLight();
 
     /**
-     * @brief Calibrate threshold for white and black field
+     * @brief Calibrate threshold for white and black field.
      * 
      */
     void calibrateFieldColor();
@@ -92,38 +94,26 @@ protected:
     Dezibot &dezibot;
 
     /**
-     * @brief Highest value for color to be recognised as white field
+     * @brief Lowest value for color to be recognised as white field.
      * 
      */
-    double isWhiteFieldTopThreshold = DEFAULT_TOP_WHITE_THRESHOLD;
+    double isWhiteFieldThreshold = DEFAULT_WHITE_THRESHOLD;
 
     /**
-     * @brief Lowest value for color to be recognised as white field
+     * @brief Highest value for color to be recognised as black field.
      * 
      */
-    double isWhiteFieldBottomThreshold = DEFAULT_BOTTOM_WHITE_THRESHOLD;
+    double isBlackFieldThreshold = DEFAULT_BLACK_THRESHOLD;
 
     /**
-     * @brief Highest value for color to be recognised as black field
-     * 
-     */
-    double isBlackFieldTopThreshold = DEFAULT_TOP_BLACK_THRESHOLD;
-
-    /**
-     * @brief Lowest value for color to be recognised as black field
-     * 
-     */
-    double isBlackFieldBottomThreshold = DEFAULT_BOTTOM_BLACK_THRESHOLD;
-
-    /**
-     * @brief Flag for setting of color correction light
+     * @brief Flag for setting of color correction light.
      * 
      */
     bool shouldTurnOnColorCorrectionLight = false;
 
 private:
     /**
-     * @brief Calibrate on white or black field
+     * @brief Calibrate on white or black field.
      * 
      * @param isWhite True if color to calibrate is white, false if black
      * @return brightness as double 
@@ -131,11 +121,54 @@ private:
     double calibrateColor(bool isWhite);
 
     /**
-     * @brief Measure brightness
+     * @brief Measure brightness.
      * 
      * @return brightness as double
      */
     double measureBrightness();
+
+    /**
+     * @brief Time between measurements of field colors in \p calibrateColor.
+     * 
+     */
+    const int CALIBRATION_TIME = 2000;
+
+    /**
+     * @brief How many fields are used to calibrate a field color in \p calibrateFieldColor.
+     * 
+     */
+    const int CALIBRATE_FIELD_COUNT = 5;
+
+    /**
+     * @brief How many measurements of current brightness are averaged in \p measureBrightness.
+     * 
+     */
+    const int MEASUREMENT_COUNT = 3;
+
+    /**
+     * @brief Time before brightness is measured in \p measureBrightness.
+     * 
+     */
+    const int DELAY_BEFORE_MEASURING = 250;
+
+    /**
+     * @brief Default value for \p isWhiteFieldThreshold.
+     * 
+     */
+    const double DEFAULT_WHITE_THRESHOLD = 220.0;
+
+    /**
+     * @brief Default value for \p isBlackFieldThreshold.
+     * 
+     */
+    const double DEFAULT_BLACK_THRESHOLD = 50.0;
+
+    /**
+     * @brief Factor to calculate threshold offset.
+     * 
+     * @see isWhiteFieldThreshold, isBlackFieldThreshold
+     */
+    const double THRESHOLD_OFFSET = 0.025;
 };
 
 #endif // ECPColorDetection_h

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
@@ -48,6 +48,9 @@ public:
     /**
      * @brief Set value for shouldTurnOnColorCorrectionLight flag
      * 
+     * Turn on color correction light if parameter turnOn is true and
+     * turn off color correction light if parameter is false
+     * 
      * @param turnOn true if correction light should be turned on else false 
      */
     void setShouldTurnOnColorCorrectionLight(bool turnOn);

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
@@ -14,16 +14,13 @@
 
 #include <Dezibot.h>
 
-#define IS_WHITE_FIELD_THRESHOLD 100.0
-
 #define COLOR_CORRECTION_LIGHT_R 43
 #define COLOR_CORRECTION_LIGHT_G 33
 #define COLOR_CORRECTION_LIGHT_B 35
 
-class ECPColorDetection {
-protected:
-    Dezibot &dezibot;
+#define CALIBRATION_TIME 5000
 
+class ECPColorDetection {
 public:
     ECPColorDetection(Dezibot &d);
 
@@ -52,6 +49,36 @@ public:
      * 
      */
     void turnOffColorCorrectionLight();
+
+    /**
+     * @brief Calibrate threshold for white and black field
+     * 
+     */
+    void calibrateFieldColor();
+
+protected:
+    Dezibot &dezibot;
+
+    /**
+     * @brief Threshold for color to be recognised as white field
+     * 
+     */
+    double isWhiteFieldThreshold;
+
+    /**
+     * @brief Threshold for color to be recognised as black field
+     * 
+     */
+    double isBlackFieldThreshold;
+
+private:
+    /**
+     * @brief Calibrate on white or black field
+     * 
+     * @param isWhite True if color to calibrate is white, false if black
+     * @return brightness as double 
+     */
+    double calibrateColor(bool isWhite);
 };
 
 #endif // ECPColorDetection_h

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
@@ -14,7 +14,7 @@
 
 #include <Dezibot.h>
 
-#define DELAY_BEFORE_MEASURING 5
+#define DELAY_BEFORE_MEASURING 20
 
 #define COLOR_CORRECTION_LIGHT_R 43
 #define COLOR_CORRECTION_LIGHT_G 33
@@ -29,7 +29,7 @@
 /**
  * @brief Color of field the dezibot is standing on.
  * 
- * Convertible to int, i.e. BLACK_FIELD == 0, WHITE_FIELD == 2
+ * Convertible to int, i.e. BLACK_FIELD == 0, WHITE_FIELD == 1
  * 
  */
 enum FieldColor {

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
@@ -19,15 +19,23 @@
 #define COLOR_CORRECTION_LIGHT_B 35
 
 #define CALIBRATION_TIME 5000
+#define DEFAULT_TOP_WHITE_THRESHOLD 248.0
+#define DEFAULT_BOTTOM_WHITE_THRESHOLD 245.0
+#define DEFAULT_TOP_BLACK_THRESHOLD 48.0
+#define DEFAULT_BOTTOM_BLACK_THRESHOLD 42.0
 
 /**
  * @brief Color of field the dezibot is standing on.
  * 
- * Convertible to int, i.e. UNAMBIGUOUS == 0, BLACK == 1, WHITE == 2
+ * Convertible to int, i.e. BLACK_FIELD == 0, WHITE_FIELD == 2
  * 
  */
 enum FieldColor {
-    UNAMBIGUOUS_FIELD, BLACK_FIELD, WHITE_FIELD
+    BLACK_FIELD, 
+    WHITE_FIELD,
+    UNAMBIGUOUS_WHITE_TO_BLACK, 
+    UNAMBIGUOUS_BLACK_TO_WHITE,
+    UNAMBIGUOUS
 };
 
 class ECPColorDetection {
@@ -85,16 +93,28 @@ protected:
     Dezibot &dezibot;
 
     /**
-     * @brief Threshold for color to be recognised as white field
+     * @brief Highest value for color to be recognised as white field
      * 
      */
-    double isWhiteFieldThreshold;
+    double isWhiteFieldTopThreshold = DEFAULT_TOP_WHITE_THRESHOLD;
 
     /**
-     * @brief Threshold for color to be recognised as black field
+     * @brief Lowest value for color to be recognised as white field
      * 
      */
-    double isBlackFieldThreshold;
+    double isWhiteFieldBottomThreshold = DEFAULT_BOTTOM_WHITE_THRESHOLD;
+
+    /**
+     * @brief Highest value for color to be recognised as black field
+     * 
+     */
+    double isBlackFieldTopThreshold = DEFAULT_TOP_BLACK_THRESHOLD;
+
+    /**
+     * @brief Lowest value for color to be recognised as black field
+     * 
+     */
+    double isBlackFieldBottomThreshold = DEFAULT_BOTTOM_BLACK_THRESHOLD;
 
     /**
      * @brief Flag for setting of color correction light

--- a/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPColorDetection/ECPColorDetection.h
@@ -46,6 +46,20 @@ public:
     FieldColor getFieldColor();
 
     /**
+     * @brief Set value for shouldTurnOnColorCorrectionLight flag
+     * 
+     * @param turnOn true if correction light should be turned on else false 
+     */
+    void setShouldTurnOnColorCorrectionLight(bool turnOn);
+
+    /**
+     * @brief Return value of shouldTurnOnColorCorrectionLight flag
+     * 
+     * @return @see shouldTurnOnColorCorrectionLight
+     */
+    bool getShouldTurnOnColorCorrectionLight();
+
+    /**
      * @brief Turn on the LED on the bottom of the Dezibot.
      * 
      * The light should help the identification of the field color even in a dimly-lit room.
@@ -78,6 +92,12 @@ protected:
      * 
      */
     double isBlackFieldThreshold;
+
+    /**
+     * @brief Flag for setting of color correction light
+     * 
+     */
+    bool shouldTurnOnColorCorrectionLight = false;
 
 private:
     /**

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -59,6 +59,10 @@ void ECPMovement::turnRight(
 // PRIVATE FUNCTIONS
 // -----------------------------------------------------------------------------
 
+ECPColorDetection* ECPMovement::getECPColorDetection() {
+    return &ecpColorDetection;
+}
+
 void ECPMovement::moveForward(int timeMovement, int timeBreak) {
     dezibot.motion.move(0, movementCalibration);
     delay(timeMovement);

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -18,7 +18,7 @@ void ECPMovement::turnLeft(
     ECPChessField currentField, 
     ECPDirection intendedDirection
 ) {
-    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
+    const int startColor = ecpColorDetection.getFieldColor();
     const int initialAngle = ecpSignalDetection.measureDezibotAngle();
     
     // if dezibot initially faces 270°, subtract 90° to turn left, resulting
@@ -29,8 +29,8 @@ void ECPMovement::turnLeft(
     const bool wasRotationSuccessful = rotateToAngle(goalAngle, initialAngle);
 
     delay(MEASURING_DELAY); // for better measuring results
-    const bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
-    if (isCurrentlyOnWhite != hasStartedOnWhite || !wasRotationSuccessful) {
+    const int currentColor = ecpColorDetection.getFieldColor();
+    if (currentColor != startColor || !wasRotationSuccessful) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
     }
 };
@@ -39,7 +39,7 @@ void ECPMovement::turnRight(
     ECPChessField currentField, 
     ECPDirection intendedDirection
 ) {
-    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
+    const int startColor = ecpColorDetection.getFieldColor();
     const int initialAngle = ecpSignalDetection.measureDezibotAngle();
 
     // if dezibot initially faces 180°, add 90° to turn left, resulting
@@ -49,8 +49,8 @@ void ECPMovement::turnRight(
     const bool wasRotationSuccessful = rotateToAngle(goalAngle, initialAngle);
 
     delay(MEASURING_DELAY); // for better measuring results
-    const bool isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
-    if (isCurrentlyOnWhite != hasStartedOnWhite || !wasRotationSuccessful) {
+    const int currentColor = ecpColorDetection.getFieldColor();
+    if (currentColor != startColor || !wasRotationSuccessful) {
         displayRotionCorrectionRequest(currentField, intendedDirection);
     }
 };
@@ -86,7 +86,7 @@ void ECPMovement::moveToNextField() {
     }
 };
 
-void ECPMovement::displayRotionCorrectionRequest(
+void ECPMovement::displayRotationCorrectionRequest(
     ECPChessField currentField, 
     ECPDirection intendedDirection
 ) {

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -8,9 +8,21 @@ ECPMovement::ECPMovement(
     ecpSignalDetection(ECPSignalDetection(dezibot)),
     movementCalibration(movementCalibration) {};
 
-void ECPMovement::move(uint numberOfFields) {
+void ECPMovement::move(
+    uint numberOfFields, 
+    ECPChessField intendedField, 
+    ECPDirection intendedDirection
+) {
     for (size_t i = 0; i < numberOfFields; i++) {
-        moveToNextField();
+        bool successfulMovement = moveToNextField();
+        
+        if (!successfulMovement) {
+            displayForwardMovementCorrectionRequest(
+                intendedField, 
+                intendedDirection
+            );
+            break;
+        }
     }
 };
 
@@ -31,7 +43,7 @@ void ECPMovement::turnLeft(
     delay(MEASURING_DELAY); // for better measuring results
     const int currentColor = ecpColorDetection.getFieldColor();
     if (currentColor != startColor || !wasRotationSuccessful) {
-        displayRotionCorrectionRequest(currentField, intendedDirection);
+        displayRotationCorrectionRequest(currentField, intendedDirection);
     }
 };
 
@@ -51,7 +63,7 @@ void ECPMovement::turnRight(
     delay(MEASURING_DELAY); // for better measuring results
     const int currentColor = ecpColorDetection.getFieldColor();
     if (currentColor != startColor || !wasRotationSuccessful) {
-        displayRotionCorrectionRequest(currentField, intendedDirection);
+        displayRotationCorrectionRequest(currentField, intendedDirection);
     }
 };
 
@@ -70,20 +82,33 @@ void ECPMovement::moveForward(int timeMovement, int timeBreak) {
     delay(timeBreak);
 };
 
-void ECPMovement::moveToNextField() {
+bool ECPMovement::moveToNextField() {
     const int startColor = ecpColorDetection.getFieldColor();
     const int wantedColor = startColor == 1 ? startColor + 1 : startColor -1;
     const int stopoverColor = wantedColor + 2;
     int currentColor = startColor;
+    int currentIteration = 0;
 
+    // reach middle of the next field with the front leg
     while (currentColor != stopoverColor) {
+        if (currentIteration == MAX_ITERATIONS) {
+            return false;
+        }
         moveForward(FORWARD_TIME, MOVEMENT_BREAK);
         currentColor = ecpColorDetection.getFieldColor();
+        currentIteration++;
     }
+
+    // move further to place the whole dezibot on the field
     while (currentColor != wantedColor) {
         moveForward(FORWARD_TIME, MOVEMENT_BREAK);
         currentColor = ecpColorDetection.getFieldColor();
+        if (currentColor == 4) { // unambiguous
+            return false;
+        }
     }
+
+    return true;
 };
 
 void ECPMovement::displayRotationCorrectionRequest(
@@ -91,12 +116,26 @@ void ECPMovement::displayRotationCorrectionRequest(
     ECPDirection intendedDirection
 ) {
     String request = "Faulty rotation\nPlease correct\nmy position in\n" 
-        + String(ROTATION_CORRECTION_TIME/1000) + " seconds to\n\n> " 
+        + String(MANUEL_CORRECTION_TIME/1000) + " seconds to\n\n> " 
         + currentField.toString() + " " + directionToString(intendedDirection) 
         + "\n\n Thank you!";
     dezibot.display.clear();
     dezibot.display.print(request);
-    delay(ROTATION_CORRECTION_TIME);
+    delay(MANUEL_CORRECTION_TIME);
+    dezibot.display.clear();
+};
+
+void ECPMovement::displayForwardMovementCorrectionRequest(
+    ECPChessField intendedField, 
+    ECPDirection intendedDirection
+) {
+    String request = "Faulty movement\nPlease correct\nmy position in\n" 
+        + String(MANUEL_CORRECTION_TIME/1000) + " seconds to\n\n> " 
+        + intendedField.toString() + " " + directionToString(intendedDirection) 
+        + "\n\n Thank you!";
+    dezibot.display.clear();
+    dezibot.display.print(request);
+    delay(MANUEL_CORRECTION_TIME);
     dezibot.display.clear();
 };
 

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -91,8 +91,7 @@ void ECPMovement::setShouldTurnOnColorCorrectionLight(bool turnOn) {
 // -----------------------------------------------------------------------------
 
 void ECPMovement::moveForward(int timeMovement) {
-    dezibot.motion.right.setSpeed(movementCalibration + 100);
-    dezibot.motion.left.setSpeed(movementCalibration);
+    dezibot.motion.move(0, movementCalibration);
     delay(timeMovement);
     dezibot.motion.stop();
 };

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -67,12 +67,13 @@ void ECPMovement::moveForward(int timeMovement, int timeBreak) {
 };
 
 void ECPMovement::moveToNextField() {
-    const bool hasStartedOnWhite = ecpColorDetection.isWhiteField();
-    bool isCurrentlyOnWhite = hasStartedOnWhite;
+    const int startColor = ecpColorDetection.getFieldColor();
+    const int wantedColor = startColor == 1 ? startColor + 1 : startColor -1;
+    int currentColor = startColor;
 
-    while (isCurrentlyOnWhite == hasStartedOnWhite) {
+    while (currentColor != wantedColor) {
         moveForward(FORWARD_TIME, MOVEMENT_BREAK);
-        isCurrentlyOnWhite = ecpColorDetection.isWhiteField();
+        currentColor = ecpColorDetection.getFieldColor();
     }
 };
 

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.cpp
@@ -73,8 +73,13 @@ void ECPMovement::moveForward(int timeMovement, int timeBreak) {
 void ECPMovement::moveToNextField() {
     const int startColor = ecpColorDetection.getFieldColor();
     const int wantedColor = startColor == 1 ? startColor + 1 : startColor -1;
+    const int stopoverColor = wantedColor + 2;
     int currentColor = startColor;
 
+    while (currentColor != stopoverColor) {
+        moveForward(FORWARD_TIME, MOVEMENT_BREAK);
+        currentColor = ecpColorDetection.getFieldColor();
+    }
     while (currentColor != wantedColor) {
         moveForward(FORWARD_TIME, MOVEMENT_BREAK);
         currentColor = ecpColorDetection.getFieldColor();

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -116,7 +116,7 @@ private:
      * @param currentField Field of the dezibot
      * @param intendedDirection Direction the dezibot should look at after rotation
      */
-    void displayRotionCorrectionRequest(
+    void displayRotationCorrectionRequest(
         ECPChessField currentField, 
         ECPDirection intendedDirection
     );

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -19,7 +19,7 @@
 #include <ECPSignalDetection/ECPSignalDetection.h>
 
 #define FORWARD_TIME 750
-#define MOVEMENT_BREAK 375
+#define MOVEMENT_BREAK 100
 #define ROTATION_SPEED 8192
 
 #define DEFAULT_MOVEMENT_CALIBRATION 3900

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -19,7 +19,6 @@
 #include <ECPSignalDetection/ECPSignalDetection.h>
 
 #define FORWARD_TIME 750
-#define MOVEMENT_BREAK 100
 #define ROTATION_SPEED 8192
 
 #define DEFAULT_MOVEMENT_CALIBRATION 3900
@@ -80,14 +79,7 @@ public:
     void turnRight(ECPChessField currentField, ECPDirection intendedDirection);
 
     /**
-     * @brief Set value for ECPColorDetection::shouldTurnOnColorCorrectionLight flag.
-     * 
-     * @see ECPColorDetection::setShouldTurnOnColorCorrectionLight
-     */
-    void setShouldTurnOnColorCorrectionLight(bool turnOn);
-
-    /**
-     * @brief Calibrate threshold for white and black field.
+     * @brief Calibrate threshold for white and black field using color sensor.
      * 
      * Threshold is used to determine if the dezibot is standing on a white or black field
      * 
@@ -98,10 +90,36 @@ public:
      */
     void calibrateFieldColor();
 
+    /**
+     * @brief Calibrate threshold for white and black field using infrared.
+     * 
+     * Threshold is used to determine if the dezibot is standing on a white or black field
+     * 
+     * Needed to adapt to current light conditions
+     * Default values may compromise movement on the chess field
+     * 
+     * @see ECPColorDetection::calibrateIRFieldColor
+     */
+    void calibrateIRFieldColor();
+
+    /**
+     * @brief Set value for \p ECPColorDetection::useInfraredColorDetection flag.
+     * 
+     * @param useIR true if infrared color detection should be used, false otherwise
+     */
+    void setColorDetectionMode(bool useIR);
+
+    /**
+     * @brief Set value for \p ECPColorDetection::shouldTurnOnColorCorrectionLight flag.
+     * 
+     * @param turnOn true if correction light should be turned on, false otherwise
+     */
+    void setShouldTurnOnColorCorrectionLight(bool turnOn);
+
 protected:
     Dezibot &dezibot;
-    ECPColorDetection ecpColorDetection;
     ECPSignalDetection ecpSignalDetection;
+    ECPColorDetection ecpColorDetection;
 
     /**
      * @brief Value to calibrate movement.
@@ -118,9 +136,8 @@ private:
      * To minimize drift, a break is implemented after each movement.
      * 
      * @param timeMovement in ms - how long the dezibot should move.
-     * @param timeBreak in ms - how long the dezibot should pause.
      */
-    void moveForward(int timeMovement, int timeBreak);
+    void moveForward(int timeMovement);
 
     /**
      * @brief Move straight to the next field.
@@ -134,7 +151,7 @@ private:
     bool moveToNextField();
 
     /**
-     * Print request to correct dezibot on the board after faulty rotation
+     * Print request to correct dezibot on the board after faulty rotation.
      * 
      * The user has 10 seconds to correct the position and direction of the dezibot
      * 
@@ -147,7 +164,7 @@ private:
     );
 
     /**
-     * Print request to correct dezibot on the board after faulty forward movement
+     * Print request to correct dezibot on the board after faulty forward movement.
      * 
      * The user has 10 seconds to correct the position and direction of the dezibot
      * 

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -69,6 +69,13 @@ public:
      */
     void turnRight(ECPChessField currentField, ECPDirection intendedDirection);
 
+    /**
+     * @brief Return pointer to ECPColorDetection instance
+     * 
+     * @return ecpColorDetection
+     */
+    ECPColorDetection* getECPColorDetection();
+
 protected:
     Dezibot &dezibot;
     ECPColorDetection ecpColorDetection;

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -27,7 +27,7 @@
 
 #define MANUEL_CORRECTION_TIME 10000
 
-#define MAX_ITERATIONS 20
+#define MAX_ITERATIONS 30
 
 class ECPMovement {
 public:
@@ -80,11 +80,23 @@ public:
     void turnRight(ECPChessField currentField, ECPDirection intendedDirection);
 
     /**
-     * @brief Return pointer to ECPColorDetection instance
+     * @brief Set value for ECPColorDetection::shouldTurnOnColorCorrectionLight flag.
      * 
-     * @return ecpColorDetection
+     * @see ECPColorDetection::setShouldTurnOnColorCorrectionLight
      */
-    ECPColorDetection* getECPColorDetection();
+    void setShouldTurnOnColorCorrectionLight(bool turnOn);
+
+    /**
+     * @brief Calibrate threshold for white and black field.
+     * 
+     * Threshold is used to determine if the dezibot is standing on a white or black field
+     * 
+     * Needed to adapt to current light conditions
+     * Default values may compromise movement on the chess field
+     * 
+     * @see ECPColorDetection::calibrateFieldColor
+     */
+    void calibrateFieldColor();
 
 protected:
     Dezibot &dezibot;

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -26,7 +26,7 @@
 
 #define MANUEL_CORRECTION_TIME 10000
 
-#define MAX_ITERATIONS 30
+#define MAX_ITERATIONS 10
 
 class ECPMovement {
 public:

--- a/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
+++ b/example/EmbeddedChessPieces/src/ECPMovement/ECPMovement.h
@@ -14,16 +14,20 @@
 
 #include <Dezibot.h>
 
-#include "ECPChessLogic/ECPChessField.h"
+#include <ECPChessLogic/ECPChessField.h>
 #include <ECPColorDetection/ECPColorDetection.h>
 #include <ECPSignalDetection/ECPSignalDetection.h>
 
 #define FORWARD_TIME 750
 #define MOVEMENT_BREAK 375
 #define ROTATION_SPEED 8192
-#define ROTATION_CORRECTION_TIME 10000
+
 #define DEFAULT_MOVEMENT_CALIBRATION 3900
 #define MEASURING_DELAY 100
+
+#define MANUEL_CORRECTION_TIME 10000
+
+#define MAX_ITERATIONS 20
 
 class ECPMovement {
 public:
@@ -42,8 +46,14 @@ public:
      * @brief Move chess piece given number of fields forward.
      * 
      * @param numberOfFields Number of fields the dezibot should move forward
+     * @param intendedField Field of the dezibot
+     * @param intendedDirection Direction the dezibot should look at after movement
      */
-    void move(uint numberOfFields);
+    void move(
+        uint numberOfFields, 
+        ECPChessField intendedField, 
+        ECPDirection intendedDirection
+    );
 
     /**
      * @brief Turn 90 degrees left.
@@ -105,8 +115,11 @@ private:
      * 
      * Default interval of movement before checking the field color
      * is defined in MOVEMENT_TIME and MOVEMENT_BREAK.
+     * 
+     * @return true if fieldColors indicate successful movement
+     * @return false if fieldColors indicate faulty movement
      */
-    void moveToNextField();
+    bool moveToNextField();
 
     /**
      * Print request to correct dezibot on the board after faulty rotation
@@ -118,6 +131,19 @@ private:
      */
     void displayRotationCorrectionRequest(
         ECPChessField currentField, 
+        ECPDirection intendedDirection
+    );
+
+    /**
+     * Print request to correct dezibot on the board after faulty forward movement
+     * 
+     * The user has 10 seconds to correct the position and direction of the dezibot
+     * 
+     * @param intendedField Field of the dezibot
+     * @param intendedDirection Direction the dezibot should look at after movement
+     */
+    void displayForwardMovementCorrectionRequest(
+        ECPChessField intendedField, 
         ECPDirection intendedDirection
     );
 

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -59,4 +59,21 @@ int ECPSignalDetection::measureSignalAngle() {
 int ECPSignalDetection::measureDezibotAngle() {
     int signalAngle = measureSignalAngle();
     return (360 - signalAngle) % 360;
-}
+};
+
+int ECPSignalDetection::cumulateInfraredValues() {
+    // TODO: use normalized values?
+    const photoTransistors sensors[] = { IR_FRONT, IR_RIGHT, IR_BACK, IR_LEFT };
+    int cumulatedValues = 0;
+
+    // measure all four IR signal values
+    for (size_t i = 0; i < 4; i++) {
+        cumulatedValues += dezibot.lightDetection.getAverageValue(
+            sensors[i],
+            MEASUREMENT_COUNT,
+            TIME_BETWEEN_MEASUREMENTS
+        );
+    }
+
+    return cumulatedValues;
+};

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.cpp
@@ -61,8 +61,13 @@ int ECPSignalDetection::measureDezibotAngle() {
     return (360 - signalAngle) % 360;
 };
 
-int ECPSignalDetection::cumulateInfraredValues() {
-    // TODO: use normalized values?
+int ECPSignalDetection::cumulateInfraredValues(bool turnOnIRLight) {
+    if (turnOnIRLight) {
+        delay(DELAY_BEFORE_ACTION);
+        dezibot.infraredLight.bottom.turnOn();
+        delay(DELAY_AFTER_ACTION);
+    }
+
     const photoTransistors sensors[] = { IR_FRONT, IR_RIGHT, IR_BACK, IR_LEFT };
     int cumulatedValues = 0;
 
@@ -73,6 +78,11 @@ int ECPSignalDetection::cumulateInfraredValues() {
             MEASUREMENT_COUNT,
             TIME_BETWEEN_MEASUREMENTS
         );
+    }
+
+    if (turnOnIRLight) {
+        dezibot.infraredLight.bottom.turnOff();
+        delay(DELAY_AFTER_ACTION);
     }
 
     return cumulatedValues;

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
@@ -59,9 +59,11 @@ public:
     /**
      * @brief Measure infrared values and cumulate them.
      * 
-     * @return cumulated infrared values as int.
+     * @param turnOnIRLight, true if bottom IR LED should be turned on 
+     *        while measuring, default is true
+     * @return cumulated infrared values as int (not normalized).
      */
-    int cumulateInfraredValues();
+    int cumulateInfraredValues(bool turnOnIRLight = true);
 
 private:
     /**
@@ -88,6 +90,20 @@ private:
      * 
      */
     static constexpr float MIN_THRESHOLD_MEASUREMENTS = 0.10f;
+
+    /**
+     * @brief Delay before turning on infrared LED in \p cumulateInfraredValues.
+     * 
+     * Needed for reliable infrared light when turned on.
+     */
+    static const int DELAY_BEFORE_ACTION = 500;
+
+    /**
+     * @brief Delay after turning on infrared LED in \p cumulateInfraredValues.
+     * 
+     * Needed for reliable infrared light when turned on.
+     */
+    static const int DELAY_AFTER_ACTION = 1000;
 };
 
 #endif // ECPSignalDetection_H

--- a/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
+++ b/example/EmbeddedChessPieces/src/ECPSignalDetection/ECPSignalDetection.h
@@ -56,6 +56,13 @@ public:
      */
     int measureDezibotAngle();
 
+    /**
+     * @brief Measure infrared values and cumulate them.
+     * 
+     * @return cumulated infrared values as int.
+     */
+    int cumulateInfraredValues();
+
 private:
     /**
      * @brief How many infrared signals are averaged in \p measureSignalAngle.
@@ -65,7 +72,7 @@ private:
 
     /**
      * @brief Time between measurements that are averaged to one in
-     *        \p measureSignalAngle in milliseconds,
+     *        \p measureSignalAngle and \p cumulateInfraredValues in ms.
      * 
      */
     static const int TIME_BETWEEN_MEASUREMENTS = 30;


### PR DESCRIPTION
### Changes
- Add `FieldColor`
- Update movement functions accordingly, e.g. `ECPMovement::moveToNextField`
- Add colour sensor calibration
- Add infrared colour detection with calibration
- Add sketch for IR colour detection
- Add faulty movement manuel correction request

### How to Test
- You need two dezibots to test this PR
- Run `ir_emitter.ino` on one and place it so that the side with only one leg faces in the middle of the board (but the dezibot turned off)
- Run `move_to_field.ino` on a second dezibot
- Make sure to block any sun since this influences the IR measurements heavily
- Turn on emitter dezibot if a rotation needs it, turn it off immediatly after completing the rotation

### Note
- Emitter signal greatly affects IR colour detection

Closes #15  